### PR TITLE
Add Model Context Protocol taxonomy slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ always bump at least minor; breaking schema changes bump major.
 
 ## [Unreleased]
 
+### Added
+- Add `ai/mcp` to the closed skill taxonomy for Model Context Protocol work.
+
 ### Changed
 - **Bare-name alias packages published: `redential` and `redential-cli`.**
   Two thin launcher packages, `packages/redential/` and

--- a/taxonomy.json
+++ b/taxonomy.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Closed public vocabulary of skill slugs. This file is the ONLY source of valid values for detected_skills[].slug in the bundle: a slug not listed here makes the bundle invalid. Detection maps signatures/*.json matches to these slugs — deterministically, locally, with zero network calls. Adding a slug requires a PR to this file (and a signature definition); slugs are never hardcoded in the CLI. Placeholder set, to be expanded.",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "skills": [
     { "slug": "auth/supabase-auth", "label": "Supabase Auth" },
     { "slug": "auth/nextauth", "label": "NextAuth / Auth.js" },
@@ -20,6 +20,7 @@
     { "slug": "payments/paddle", "label": "Paddle" },
     { "slug": "ai/openai-api", "label": "OpenAI API" },
     { "slug": "ai/anthropic-api", "label": "Anthropic API" },
+    { "slug": "ai/mcp", "label": "Model Context Protocol (MCP)" },
     { "slug": "ai/langchain", "label": "LangChain" },
     { "slug": "ai/langgraph", "label": "LangGraph" },
     { "slug": "ai/llamaindex", "label": "LlamaIndex" },


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

Adds the approved `ai/mcp` closed-vocabulary slug for Model Context Protocol work and bumps the taxonomy version from `1.5.1` to `1.6.0`.

MCP server/client implementation is a distinct, verifiable skill currently missing from the vocabulary. The change preserves the privacy boundary: no bundle field or shape changes, and the only newly permitted output is the exact maintainer-reviewed slug.

Prior data-boundary discussion: #17

## Checklist

- [x] Tests pass locally (`npm test`) — 687 passed
- [x] `npm run typecheck` passes
- [x] Links the prior data-boundary discussion issue: #17
- [x] No bundle schema bump required, as confirmed in #17
- [x] `CHANGELOG.md` entry added under `[Unreleased]`
- [x] No runtime dependency added

## Additional context

This is the vocabulary-only first PR. Package-map entries will follow in a separate PR after this slug lands, per the contribution contract and the accepted two-PR plan.