### PR TITLE
fix: correct singular commit wording in identity prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ always bump at least minor; breaking schema changes bump major.
 
 ## [Unreleased]
 
+### Fixed
+- Fix the author identity prompt showing "1 commits" instead of "1 commit" when a single commit is found.
+
 ## [0.6.0] - 2026-07-22
 
 ### Fixed

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -39,7 +39,7 @@ function formatCandidate(c: AuthorCandidate): string {
 // identity), just reached from two different code paths. Thousands
 // separator matches scan-command.ts's own commit-count formatting.
 function formatIdentityConfirmationPrompt(c: AuthorCandidate): string {
-  return `Found ${c.count.toLocaleString("en-US")} commits authored by ${c.email}. Use this identity? (Y/n) `;
+    return `Found ${c.count.toLocaleString("en-US")} commit${c.count === 1 ? "" : "s"} authored by ${c.email}. Use this identity? (Y/n) `;
 }
 
 export async function promptAuthors(

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -226,6 +226,15 @@ describe("promptUseGitIdentity — Y/n confirmation, Y default", () => {
     expect(out.text()).toBe("Found 1,378 commits authored by you@example.com. Use this identity? (Y/n) ");
   });
 
+   it("prints singular commit wording for one commit", async () => {
+    const out = captureOutput();
+    await promptUseGitIdentity(
+      { email: "you@example.com", count: 1 },
+      { input: lineInput(""), output: out.stream }
+    );
+    expect(out.text()).toBe("Found 1 commit authored by you@example.com. Use this identity? (Y/n) ");
+  });
+
   it("accepts on Enter (empty answer), defaulting to yes", async () => {
     const result = await promptUseGitIdentity(candidate, { input: lineInput(""), output: sinkOutput() });
     expect(result).toBe(true);
@@ -249,6 +258,12 @@ describe("promptAuthors — single candidate (Y/n confirmation, Y default)", () 
     const out = captureOutput();
     await promptAuthors([{ email: "user@example.com", count: 1378 }], { input: lineInput(""), output: out.stream });
     expect(out.text()).toBe("Found 1,378 commits authored by user@example.com. Use this identity? (Y/n) ");
+  });
+
+  it("prints singular commit wording for one commit", async () => {
+    const out = captureOutput();
+    await promptAuthors([{ email: "user@example.com", count: 1 }], { input: lineInput(""), output: out.stream });
+    expect(out.text()).toBe("Found 1 commit authored by user@example.com. Use this identity? (Y/n) ");
   });
 
   it("accepts on Enter (empty answer), defaulting to yes", async () => {


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

<!--
Every contribution should make the credential more solid, trustworthy, or
verifiable (see CONTRIBUTING.md). Explain what this change does and how it
moves that needle.
-->

Fixes the author identity prompt pluralization issue where a single commit was
displayed as "Found 1 commits authored by ...".

This change updates the prompt formatting logic to correctly use singular
"commit" when exactly one commit is found while preserving the existing plural
format for multiple commits.

Added regression tests for both identity prompt flows:
- `promptUseGitIdentity`
- `promptAuthors`

These tests verify the exact user-facing prompt output and ensure the singular
and plural cases remain correct.

Closes #21 

## Checklist

- [x] Tests pass locally (`npm test`)
- [x] `npm run typecheck` passes

### If this adds or changes a detection signature

- [ ] Includes at least one positive fixture and one negative fixture
      (the negative fixture is a genuine near-miss, not unrelated text)
- [ ] The slug used already exists in `taxonomy.json` — if it's new, that's
      a **separate** PR with a rationale, linked here: #

### If this touches WHAT data leaves the machine, or WHERE it's sent

- [ ] Links the prior "Data boundary change" discussion issue (required
      before this PR was opened): #
- [ ] Schema version bumped, with `docs/schema.md` updated
- [ ] Adds/updates a test in `test/privacy/`

### If this adds a new runtime dependency

- [ ] Written justification included below (what it does, why the
      existing stack — commander/vitest — can't do it, what it adds to
      the supply-chain surface)

### Docs and changelog

- [x] `CHANGELOG.md` entry added under `[Unreleased]` (if user-facing)
- [ ] Relevant doc in `docs/` added or updated, in English

## Additional context

<!-- Anything a reviewer needs that isn't obvious from the diff. -->

This is a small user-facing correctness fix. No detection signatures, privacy
boundaries, schema changes, or dependencies are affected.