### PR TITLE
Principle 2 amendment: append-only vault state permitted, resident processes forbidden (RFC #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ always bump at least minor; breaking schema changes bump major.
 ### Changed
 - Principle 2 ("Explicit") amended per RFC #13: append-only local state
   (a future session-receipt vault) is explicitly permitted; resident
-  processes, hooks, IDE plugins, and any auto-emit remain forbidden.
+  processes, hooks, IDE plugins, and any auto-emit remain forbidden. The
+  vault's permitted readers are enumerated (`session finish`, a voluntary
+  future `redential anchor`, `submit`); extending Principle 1's network
+  list for `redential anchor` is deferred to its own future ceremony.
   Wording co-authored with @rudi193-cmd. Docs only — no behavior change.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ always bump at least minor; breaking schema changes bump major.
 
 ## [Unreleased]
 
+### Changed
+- Principle 2 ("Explicit") amended per RFC #13: append-only local state
+  (a future session-receipt vault) is explicitly permitted; resident
+  processes, hooks, IDE plugins, and any auto-emit remain forbidden.
+  Wording co-authored with @rudi193-cmd. Docs only — no behavior change.
+
 ### Fixed
 - Fix the author identity prompt showing "1 commits" instead of "1 commit" when a single commit is found.
 

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -21,7 +21,13 @@ Nothing is uploaded without the user running `redential submit` and
 confirming. **No daemon, no watch mode, no background process**, no
 telemetry. Session bookends are one-shot commands. A vault file may persist
 **append-only receipts** between bookends; nothing reads it except the next
-one-shot `finish` or `submit`. No hooks, no IDE plugins, no auto-emit.
+one-shot command the user runs: `session finish`, a voluntary
+`redential anchor`, or `submit`. No hooks, no IDE plugins, no auto-emit.
+
+Anchoring rides `submit` or that explicit `redential anchor` one-shot,
+never a cadence the tool assumes. `redential anchor` does not exist yet;
+when it ships, adding it to Principle 1's network list is its own ceremony
+PR — this amendment changes no network promise.
 
 The distinction that matters: forbidden is anything RESIDENT — a process
 that polls, a hook that fires, anything that emits without the user typing

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -18,9 +18,19 @@ patterns). No LLMs, no remote inference, no exceptions.
 ## 2. Explicit
 
 Nothing is uploaded without the user running `redential submit` and
-confirming. There is no daemon, no watch mode, no background process, no
-telemetry. One-shot by design: git is already the journal, a retroactive scan
-reconstructs everything.
+confirming. **No daemon, no watch mode, no background process**, no
+telemetry. Session bookends are one-shot commands. A vault file may persist
+**append-only receipts** between bookends; nothing reads it except the next
+one-shot `finish` or `submit`. No hooks, no IDE plugins, no auto-emit.
+
+The distinction that matters: forbidden is anything RESIDENT — a process
+that polls, a hook that fires, anything that emits without the user typing
+a command at that moment. Permitted is inert, append-only local state that
+one-shot commands leave behind and later one-shot commands read
+(RFC: [#13](https://github.com/Redential/redential-cli/issues/13)).
+
+For scanning, one-shot stays the whole story: git is already the journal, a
+retroactive scan reconstructs everything.
 
 ## 3. Bounded output
 


### PR DESCRIPTION
The amendment step promised in #13. Core wording is @rudi193-cmd's, verbatim from his red-team comment:

> **No daemon, no watch mode, no background process.** Session bookends are one-shot commands. A vault file may persist **append-only receipts** between bookends; nothing reads it except the next one-shot `finish` or `submit`. No hooks, no IDE plugins, no auto-emit.

Plus one boundary paragraph so a future PR can't misread it: forbidden = anything resident (polling process, fired hook, auto-emit); permitted = inert append-only state written and read only by one-shot commands. The old "git is already the journal" line stays, scoped to scanning.

Docs only, no behavior change. Sean: this is your wording, flag anything you'd iterate before it merges. After this, your two reserved artifact PRs (anchor schema draft, backdated-segment fixture) have a constitution to point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)