### PR TITLE
test: RFC #13 fixture backdated-segment negative contract

### DIFF
--- a/test/fixtures/vault/backdated-segment.fixture.test.ts
+++ b/test/fixtures/vault/backdated-segment.fixture.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const FIXTURE_DIR = join(dirname(fileURLToPath(import.meta.url)), "backdated-segment");
+
+function loadJson<T>(name: string): T {
+  return JSON.parse(readFileSync(join(FIXTURE_DIR, name), "utf8")) as T;
+}
+
+/**
+ * Locks the negative fixture contract for RFC #13 vault backdating.
+ * Does NOT implement chain_verify — only documents expected rejection
+ * before vault code ships (same discipline as signature negative fixtures).
+ */
+describe("fixture:backdated-segment (vault negative)", () => {
+  const honest = loadJson<{
+    anchors: Array<{ received_at_server: string; max_finished_at_claimed: string }>;
+    epsilon_days: number;
+  }>("honest-server-anchors.json");
+
+  const forged = loadJson<{
+    submit: { max_finished_at_claimed: string; received_at_server: string; receipt_count_since_prev: number };
+  }>("forged-submit-segment.json");
+
+  const expectations = loadJson<{
+    verdict: string;
+    primary_reason: string;
+    checks: Array<{ id: string; passes: boolean }>;
+    must_not_expose_to_hiring_ui: string[];
+  }>("expectations.json");
+
+  it("declares reject verdict with segment_backdate_suspect", () => {
+    expect(expectations.verdict).toBe("reject");
+    expect(expectations.primary_reason).toBe("segment_backdate_suspect");
+  });
+
+  it("forged max_finished_at predates prior honest anchor received_at_server", () => {
+    const prior = honest.anchors.at(-1)!;
+    const forgedMax = new Date(forged.submit.max_finished_at_claimed);
+    const priorReceived = new Date(prior.received_at_server);
+    expect(forgedMax.getTime()).toBeLessThan(priorReceived.getTime());
+  });
+
+  it("epsilon_window check is expected to fail", () => {
+    const check = expectations.checks.find((c) => c.id === "epsilon_window");
+    expect(check?.passes).toBe(false);
+  });
+
+  it("gap_non_exposure check passes — rejection without gap surveillance", () => {
+    const check = expectations.checks.find((c) => c.id === "gap_non_exposure");
+    expect(check?.passes).toBe(true);
+  });
+
+  it("hiring UI must not receive gap-derived fields", () => {
+    expect(expectations.must_not_expose_to_hiring_ui).toContain("days_between_anchors");
+    expect(expectations.must_not_expose_to_hiring_ui).toContain("session_spacing_histogram");
+  });
+
+  it("forged segment is non-trivial (resume-padding scale)", () => {
+    expect(forged.submit.receipt_count_since_prev).toBeGreaterThanOrEqual(10);
+  });
+});

--- a/test/fixtures/vault/backdated-segment/README.md
+++ b/test/fixtures/vault/backdated-segment/README.md
@@ -1,0 +1,45 @@
+# fixture:backdated-segment
+
+**Status:** negative fixture — reserved for vault `chain_verify` ceremony.
+**Attack:** anchor-timing arbitrage + intra-segment backdating.
+**Thread:** [RFC #13 issue #13](https://github.com/Redential/redential-cli/issues/13)
+
+## Story
+
+An honest operator anchored twice:
+
+1. **2026-03-15** — week-1 head, 4 receipts, `activity_period: 2026-Q1`
+2. **2026-06-20** — week-16 head, 3 receipts, `activity_period: 2026-Q2`
+
+Real work happened in those windows. The operator never submitted the full
+chain.
+
+On **2026-07-22** (hiring push), an attacker fabricates **12 receipts**
+claiming `finished_at` spread across **2026-04-01 .. 2026-06-10** (the gap
+between honest anchors), splices them into a hash chain, and submits with
+`max_finished_at_claimed: 2026-06-10T18:00:00Z`.
+
+## Expected verifier outcome
+
+| Check | Result |
+| --- | --- |
+| Hash chain internal consistency | passes (attacker recomputed hashes) |
+| `head_hash` matches uploaded segment tail | passes |
+| `max_finished_at_claimed` vs prior anchor `received_at_server` + ε | **fail** → `segment_backdate_suspect` |
+| `first_anchor_at` for chain vs `received_at_server` at submit | **fail** → `anchor_timing_suspect` (if first server sighting is submit day with `receipt_count_total ≫ 1`) |
+| Gap duration exposed to hiring UI | **must not happen** (privacy default) |
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `honest-server-anchors.json` | Prior anchors already on server |
+| `forged-submit-segment.json` | Client upload attempt |
+| `expectations.json` | Machine-readable verdict contract |
+
+## Privacy note
+
+This fixture tests **backdating detection**, not gap surveillance. A correct
+implementation flags the segment as suspect without revealing *why the honest
+user had a quiet April* — only that claimed finish times are inconsistent
+with prior anchor windows.

--- a/test/fixtures/vault/backdated-segment/expectations.json
+++ b/test/fixtures/vault/backdated-segment/expectations.json
@@ -1,0 +1,37 @@
+{
+  "fixture": "backdated-segment",
+  "verdict": "reject",
+  "primary_reason": "segment_backdate_suspect",
+  "secondary_reasons": ["anchor_timing_suspect"],
+  "checks": [
+    {
+      "id": "epsilon_window",
+      "description": "max_finished_at_claimed must not predate prior anchor received_at_server by more than epsilon_days",
+      "passes": false,
+      "detail": "Prior anchor received_at_server=2026-06-20T09:15:00Z; forged max_finished_at_claimed=2026-06-10T18:00:00Z is BEFORE prior anchor — segment claims work finished before last honest anchor landed."
+    },
+    {
+      "id": "gap_non_exposure",
+      "description": "Verifier must not surface inter-anchor gap duration or session spacing",
+      "passes": true,
+      "detail": "Rejection cites timestamp inconsistency only — not 'user was inactive April-May'."
+    },
+    {
+      "id": "coarse_bucket_only",
+      "description": "Server stores activity_period quarter bucket, not per-receipt dates",
+      "passes": true,
+      "detail": "forged submit activity_period=2026-Q3 — no daily grid leaked."
+    },
+    {
+      "id": "chain_splice",
+      "description": "Silent local splice without reset_reason fork",
+      "passes": false,
+      "detail": "seq continues 1→2 with null reset_reason but segment timestamps incompatible with server history — treat as splice/backdate, not honest append."
+    }
+  ],
+  "must_not_expose_to_hiring_ui": [
+    "days_between_anchors",
+    "session_spacing_histogram",
+    "calendar_gap_map"
+  ]
+}

--- a/test/fixtures/vault/backdated-segment/forged-submit-segment.json
+++ b/test/fixtures/vault/backdated-segment/forged-submit-segment.json
@@ -1,0 +1,27 @@
+{
+  "description": "Forged submit on 2026-07-22: 12 backdated receipts claiming activity in the gap between honest anchors.",
+  "submit": {
+    "schema_version": "anchor.v0.discussion",
+    "identity_hash": "sha256:salt:example-author-7f3a9c",
+    "chain_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "seq": 2,
+    "prev_anchor_hash": "anchor-hash-seq-1-canonical-sha256-placeholder000000000000",
+    "head_hash": "3333333333333333333333333333333333333333333333333333333333333333",
+    "receipt_count_total": 19,
+    "receipt_count_since_prev": 12,
+    "max_finished_at_claimed": "2026-06-10T18:00:00Z",
+    "received_at_server": "2026-07-22T21:00:00Z",
+    "activity_period": "2026-Q3",
+    "first_anchor_at": "2026-03-15T10:00:00Z",
+    "reset_reason": null,
+    "privacy_profile": "default"
+  },
+  "segment_receipts_summary": {
+    "count": 12,
+    "claimed_finished_at_range": {
+      "earliest": "2026-04-01T09:00:00Z",
+      "latest": "2026-06-10T18:00:00Z"
+    },
+    "note": "Receipt bodies omitted — fixture tests anchor-level rejection only."
+  }
+}

--- a/test/fixtures/vault/backdated-segment/honest-server-anchors.json
+++ b/test/fixtures/vault/backdated-segment/honest-server-anchors.json
@@ -1,0 +1,40 @@
+{
+  "description": "Server-side anchor history before the forged submit. Identity and chain_id are fictional.",
+  "identity_hash": "sha256:salt:example-author-7f3a9c",
+  "chain_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "epsilon_days": 7,
+  "anchors": [
+    {
+      "schema_version": "anchor.v0.discussion",
+      "identity_hash": "sha256:salt:example-author-7f3a9c",
+      "chain_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "seq": 0,
+      "prev_anchor_hash": null,
+      "head_hash": "1111111111111111111111111111111111111111111111111111111111111111",
+      "receipt_count_total": 4,
+      "receipt_count_since_prev": 4,
+      "max_finished_at_claimed": "2026-03-14T22:30:00Z",
+      "received_at_server": "2026-03-15T10:00:00Z",
+      "activity_period": "2026-Q1",
+      "first_anchor_at": "2026-03-15T10:00:00Z",
+      "reset_reason": "genesis",
+      "privacy_profile": "default"
+    },
+    {
+      "schema_version": "anchor.v0.discussion",
+      "identity_hash": "sha256:salt:example-author-7f3a9c",
+      "chain_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "seq": 1,
+      "prev_anchor_hash": "anchor-hash-seq-0-canonical-sha256-placeholder000000000000",
+      "head_hash": "2222222222222222222222222222222222222222222222222222222222222222",
+      "receipt_count_total": 7,
+      "receipt_count_since_prev": 3,
+      "max_finished_at_claimed": "2026-06-19T17:45:00Z",
+      "received_at_server": "2026-06-20T09:15:00Z",
+      "activity_period": "2026-Q2",
+      "first_anchor_at": "2026-03-15T10:00:00Z",
+      "reset_reason": null,
+      "privacy_profile": "default"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Negative fixture locking the vault backdating attack contract for RFC #13 — #28 discipline, no `chain_verify` implementation yet.

- `test/fixtures/vault/backdated-segment/` — honest server anchors + forged segment + expectations
- `test/fixtures/vault/backdated-segment.fixture.test.ts` — six tests locking the contract

Expected verifier verdict: `segment_backdate_suspect` without gap surveillance.

Companion to anchor schema ceremony PR. Closes no issue — per [#13](https://github.com/Redential/redential-cli/issues/13).

## Test plan

- [ ] `npx vitest run test/fixtures/vault/backdated-segment.fixture.test.ts` — 6 passing
