### PR TITLE
taxonomy: add validation/zod slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ always bump at least minor; breaking schema changes bump major.
 
 ## [Unreleased]
 
+### Added
+- Add `validation/zod` to the closed skill taxonomy for Zod work
+- Add `frontend/storybook` to the closed skill taxonomy for Storybook work
+
 ### Changed
 - Principle 2 ("Explicit") amended per RFC #13: append-only local state
   (a future session-receipt vault) is explicitly permitted; resident

--- a/taxonomy.json
+++ b/taxonomy.json
@@ -218,4 +218,5 @@
     { "slug": "payments/paddle-webhook-flow", "label": "Paddle webhook flow" },
     { "slug": "validation/zod", "label": "Zod" },
     { "slug": "frontend/storybook", "label": "Storybook" }
+  ]
 }

--- a/taxonomy.json
+++ b/taxonomy.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Closed public vocabulary of skill slugs. This file is the ONLY source of valid values for detected_skills[].slug in the bundle: a slug not listed here makes the bundle invalid. Detection maps signatures/*.json matches to these slugs — deterministically, locally, with zero network calls. Adding a slug requires a PR to this file (and a signature definition); slugs are never hardcoded in the CLI. Placeholder set, to be expanded.",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "skills": [
     { "slug": "auth/supabase-auth", "label": "Supabase Auth" },
     { "slug": "auth/nextauth", "label": "NextAuth / Auth.js" },
@@ -216,6 +216,6 @@
     { "slug": "payments/mercadopago-flow", "label": "Mercado Pago payment flow" },
     { "slug": "payments/lemonsqueezy-webhook-flow", "label": "Lemon Squeezy webhook flow" },
     { "slug": "payments/paddle-webhook-flow", "label": "Paddle webhook flow" },
-    { "slug": "validation/zod", "label": "Zod" }
-  ]
+    { "slug": "validation/zod", "label": "Zod" },
+    { "slug": "frontend/storybook", "label": "Storybook" }
 }

--- a/taxonomy.json
+++ b/taxonomy.json
@@ -215,6 +215,7 @@
     { "slug": "payments/paypal-webhook-flow", "label": "PayPal webhook flow" },
     { "slug": "payments/mercadopago-flow", "label": "Mercado Pago payment flow" },
     { "slug": "payments/lemonsqueezy-webhook-flow", "label": "Lemon Squeezy webhook flow" },
-    { "slug": "payments/paddle-webhook-flow", "label": "Paddle webhook flow" }
+    { "slug": "payments/paddle-webhook-flow", "label": "Paddle webhook flow" },
+    { "slug": "validation/zod", "label": "Zod" }
   ]
 }


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

<!--
Every contribution should make the credential more solid, trustworthy, or
verifiable (see CONTRIBUTING.md). Explain what this change does and how it
moves that needle.
-->
Adds the validation/zod closed-vocabulary slug and introduces a new validation taxonomy category. This follows the north star. 

Rationale for a new category, not an existing one: `Zod` didn't cleanly fit any current bucket. Unlike `backend/`, `frontend/`, etc., it's used identically on both sides — as form validation on the frontend and request/schema validation on the backend, often in the same TypeScript codebase. Filing it under `backend/` would misrepresent what's actually being detected. `validation/` follows the same pattern as existing function-based categories like `testing/` and `observability/`, which group by what the tool does rather than which layer it runs in. Other validators (Yup, Joi, Valibot, etc.) would have a natural home here too if added later.

## Checklist

- [X] Tests pass locally (`npm test`)
- [X] `npm run typecheck` passes

### If this adds or changes a detection signature

- [ ] Includes at least one positive fixture and one negative fixture
      (the negative fixture is a genuine near-miss, not unrelated text)
- [ ] The slug used already exists in `taxonomy.json` — if it's new, that's
      a **separate** PR with a rationale, linked here: #

### If this touches WHAT data leaves the machine, or WHERE it's sent

- [ ] Links the prior "Data boundary change" discussion issue (required
      before this PR was opened): #
- [ ] Schema version bumped, with `docs/schema.md` updated
- [ ] Adds/updates a test in `test/privacy/`

### If this adds a new runtime dependency

- [ ] Written justification included below (what it does, why the
      existing stack — commander/vitest — can't do it, what it adds to
      the supply-chain surface)

### Docs and changelog

- [ ] `CHANGELOG.md` entry added under `[Unreleased]` (if user-facing)
- [ ] Relevant doc in `docs/` added or updated, in English

## Additional context

<!-- Anything a reviewer needs that isn't obvious from the diff. -->
