### PR TITLE
fix: improve guidance for non-interactive prompt errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,21 @@ always bump at least minor; breaking schema changes bump major.
 ## [Unreleased]
 
 ### Fixed
+- Fix the author identity prompt showing "1 commits" instead of "1 commit" when a single commit is found.
 - Improved non-interactive prompt errors by adding actionable guidance to use `--author <email>` and `--yes` when author identity selection or authorization confirmation cannot be completed because input is unavailable.
+
+### Added
+- Add `validation/zod` to the closed skill taxonomy for Zod work.
+- Add `frontend/storybook` to the closed skill taxonomy for Storybook work.
+
+### Changed
+- Principle 2 ("Explicit") amended per RFC #13: append-only local state
+  (a future session-receipt vault) is explicitly permitted; resident
+  processes, hooks, IDE plugins, and any auto-emit remain forbidden. The
+  vault's permitted readers are enumerated (`session finish`, a voluntary
+  future `redential anchor`, `submit`); extending Principle 1's network
+  list for `redential anchor` is deferred to its own future ceremony.
+  Wording co-authored with @rudi193-cmd. Docs only — no behavior change.
 
 
 ## [0.6.0] - 2026-07-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ always bump at least minor; breaking schema changes bump major.
 
 ## [Unreleased]
 
+### Fixed
+- Improved non-interactive prompt errors by adding actionable guidance to use `--author <email>` and `--yes` when author identity selection or authorization confirmation cannot be completed because input is unavailable.
+
+
 ## [0.6.0] - 2026-07-22
 
 ### Fixed

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -57,7 +57,7 @@ export async function promptAuthors(
       const answer = await questionOrThrowOnClose(
         rl,
         formatIdentityConfirmationPrompt(only),
-        "Input closed before an author identity was selected."
+        "Input closed before an author identity was selected. Use --author <email> and --yes for non-interactive runs."
       );
       const trimmed = answer.trim().toLowerCase();
       return trimmed === "" || trimmed.startsWith("y") ? [only.email] : [];
@@ -70,7 +70,7 @@ export async function promptAuthors(
     const answer = await questionOrThrowOnClose(
       rl,
       "Enter the numbers, comma-separated (e.g. 1,3): ",
-      "Input closed before an author identity was selected."
+      "Input closed before an author identity was selected. Use --author <email> and --yes for non-interactive runs."
     );
     const indices = answer
       .split(",")
@@ -97,7 +97,7 @@ export async function promptUseGitIdentity(
     const answer = await questionOrThrowOnClose(
       rl,
       formatIdentityConfirmationPrompt(candidate),
-      "Input closed before an author identity was selected."
+      "Input closed before an author identity was selected. Use --author <email> and --yes for non-interactive runs."
     );
     const trimmed = answer.trim().toLowerCase();
     return trimmed === "" || trimmed.startsWith("y");
@@ -124,7 +124,7 @@ export async function promptConfirmAttestation(
     const answer = await questionOrThrowOnClose(
       rl,
       `${ATTESTATION_TEXT} (y/N) `,
-      "Input closed before authorization was confirmed."
+      "Input closed before authorization was confirmed. Use --author <email> and --yes for non-interactive runs."
     );
     return answer.trim().toLowerCase().startsWith("y");
   } finally {

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -78,7 +78,9 @@ describe("prompt EOF handling", () => {
   it("promptConfirmAttestation rejects when input closes before an answer", async () => {
     await expect(
       promptConfirmAttestation({ input: endedInput(), output: sinkOutput() })
-    ).rejects.toBeInstanceOf(ScanError);
+    ).rejects.toThrow(
+      "Input closed before authorization was confirmed. Use --author <email> and --yes for non-interactive runs."
+    );
   });
 
   it("promptAuthors rejects when input closes before an answer", async () => {
@@ -87,7 +89,9 @@ describe("prompt EOF handling", () => {
         input: endedInput(),
         output: sinkOutput(),
       })
-    ).rejects.toBeInstanceOf(ScanError);
+    ).rejects.toThrow(
+      "Input closed before an author identity was selected. Use --author <email> and --yes for non-interactive runs."
+    );
   });
 
   it("promptConfirmUpload rejects when input closes before an answer", async () => {
@@ -99,7 +103,9 @@ describe("prompt EOF handling", () => {
   it("promptUseGitIdentity rejects when input closes before an answer", async () => {
     await expect(
       promptUseGitIdentity({ email: "a@example.com", count: 1 }, { input: endedInput(), output: sinkOutput() })
-    ).rejects.toBeInstanceOf(ScanError);
+    ).rejects.toThrow(
+      "Input closed before an author identity was selected. Use --author <email> and --yes for non-interactive runs."
+    );
   });
 
   it("promptContinueLocally rejects when input closes before an answer", async () => {


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

- This PR improves the user experience for non-interactive CLI runs by making EOF prompt errors actionable. When the CLI cannot read input (for example, in CI or GitHub Actions), the error messages now tell users to use `--author <email>` and `--yes` instead of only reporting that the input was closed.
- This makes the CLI easier to use in automated environments by helping users recover from the error without needing to consult the documentation.

## Checklist

- [x] Tests pass locally (`npm test`)
- [x] `npm run typecheck` passes

### Docs and changelog

- [x] `CHANGELOG.md` entry added under `[Unreleased]` (if user-facing)
- [ ] Relevant doc in `docs/` added or updated, in English

Closes #22 

## Additional context

- Updated the EOF error messages for author identity selection and authorization confirmation to include actionable guidance for non-interactive runs.
- Updated the corresponding unit tests to assert the new error messages.