### PR TITLE
fix: add missing package map entries for wrangler and prisma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ always bump at least minor; breaking schema changes bump major.
 
 ## [Unreleased]
 
+### Fixed
+- Map the `prisma` and `wrangler` packages to their existing taxonomy slugs, closing package detection gaps.
+
 ### Added
 - Add `validation/zod` to the closed skill taxonomy for Zod work
 - Add `frontend/storybook` to the closed skill taxonomy for Storybook work

--- a/signatures/package-map.json
+++ b/signatures/package-map.json
@@ -130,6 +130,7 @@
     "@prisma/client": "db/prisma",
     "@prisma/extension-accelerate": "db/prisma",
     "@prisma/migrate": "db/prisma",
+    "prisma": "db/prisma",
     "drizzle-orm": "db/drizzle",
     "drizzle-kit": "db/drizzle",
     "drizzle-zod": "db/drizzle",
@@ -356,6 +357,7 @@
     "@cloudflare/kv-asset-handler": "infra/cloudflare-workers",
     "@cloudflare/next-on-pages": "infra/cloudflare-workers",
     "miniflare": "infra/cloudflare-workers",
+    "wrangler": "infra/cloudflare-workers",
 
     "@trigger.dev/sdk": "queues/trigger-dev",
     "@trigger.dev/nextjs": "queues/trigger-dev",


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

This PR adds missing package mappings for existing taxonomy slugs in `signatures/package-map.json`:

- `wrangler` → `infra/cloudflare-workers`
- `prisma` → `db/prisma`

These mappings close detection gaps for projects that use the Cloudflare Workers CLI (`wrangler`) or the Prisma CLI (`prisma`) without introducing new taxonomy slugs or changing detection logic. This improves detection coverage, making credentials more complete and reliable.

## Checklist

- [x] Tests pass locally (`npm test`)
- [x] `npm run typecheck` passes

### If this adds or changes a detection signature

- [ ] Includes at least one positive fixture and one negative fixture
      (the negative fixture is a genuine near-miss, not unrelated text)
- [x] The slug used already exists in `taxonomy.json` — if it's new, that's
      a **separate** PR with a rationale, linked here: #

### If this touches WHAT data leaves the machine, or WHERE it's sent

- [ ] Links the prior "Data boundary change" discussion issue (required
      before this PR was opened): #
- [ ] Schema version bumped, with `docs/schema.md` updated
- [ ] Adds/updates a test in `test/privacy/`

### If this adds a new runtime dependency

- [ ] Written justification included below (what it does, why the
      existing stack — commander/vitest — can't do it, what it adds to
      the supply-chain surface)

### Docs and changelog

- [x] `CHANGELOG.md` entry added under `[Unreleased]` (if user-facing)
- [ ] Relevant doc in `docs/` added or updated, in English

Closes #16 

## Additional context

This change only adds missing package mappings for existing taxonomy slugs. No scanner logic or taxonomy entries were modified.