### PR TITLE
fix: improve EOF errors for submit prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ always bump at least minor; breaking schema changes bump major.
 ### Fixed
 - Fix the author identity prompt showing "1 commits" instead of "1 commit" when a single commit is found.
 - Improved non-interactive prompt errors by adding actionable guidance to use `--author <email>` and `--yes` when author identity selection or authorization confirmation cannot be completed because input is unavailable.
+- Improved non-interactive submit prompt errors by adding actionable guidance to use `--confirm-upload` and `--label` when upload confirmation or private label input cannot be completed because input is unavailable.
 
 ### Added
 - Add `validation/zod` to the closed skill taxonomy for Zod work.

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -177,7 +177,7 @@ export async function promptPrivateLabel(streams: PromptStreams = DEFAULT_STREAM
       const answer = await questionOrThrowOnClose(
         rl,
         PRIVATE_LABEL_PROMPT_TEXT,
-        "Input closed before a private label was entered."
+        "Input closed before a private label was entered. Use --label for non-interactive runs."
       );
       try {
         return validatePrivateLabel(answer);
@@ -207,7 +207,7 @@ export async function promptConfirmUpload(streams: PromptStreams = DEFAULT_STREA
     const answer = await questionOrThrowOnClose(
       rl,
       "Upload this bundle? (y/n) ",
-      "Input closed before the upload was confirmed."
+      "Input closed before the upload was confirmed. Use --confirm-upload for non-interactive runs."
     );
     return answer.trim().toLowerCase().startsWith("y");
   } finally {

--- a/test/prompt.test.ts
+++ b/test/prompt.test.ts
@@ -97,7 +97,9 @@ describe("prompt EOF handling", () => {
   it("promptConfirmUpload rejects when input closes before an answer", async () => {
     await expect(
       promptConfirmUpload({ input: endedInput(), output: sinkOutput() })
-    ).rejects.toBeInstanceOf(ScanError);
+    ).rejects.toThrow(
+      "Input closed before the upload was confirmed. Use --confirm-upload for non-interactive runs."
+    );
   });
 
   it("promptUseGitIdentity rejects when input closes before an answer", async () => {
@@ -117,7 +119,9 @@ describe("prompt EOF handling", () => {
   it("promptPrivateLabel rejects when input closes before an answer", async () => {
     await expect(
       promptPrivateLabel({ input: endedInput(), output: sinkOutput() })
-    ).rejects.toBeInstanceOf(ScanError);
+    ).rejects.toThrow(
+      "Input closed before a private label was entered. Use --label for non-interactive runs."
+    );
   });
 });
 


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

This PR improves the EOF error messages for submit-side non-interactive prompts by adding actionable guidance that points users to the appropriate CLI flags:

- `--confirm-upload` for upload confirmation
- `--label` for the private label prompt

These changes make it clear how to successfully run `submit` in non-interactive environments, improving usability without changing submission behaviour.

## Checklist

- [x] Tests pass locally (`npm test`)
- [x] `npm run typecheck` passes

### If this adds or changes a detection signature

- [ ] Includes at least one positive fixture and one negative fixture
      (the negative fixture is a genuine near-miss, not unrelated text)
- [ ] The slug used already exists in `taxonomy.json` — if it's new, that's
      a **separate** PR with a rationale, linked here: #

### If this touches WHAT data leaves the machine, or WHERE it's sent

- [ ] Links the prior "Data boundary change" discussion issue (required
      before this PR was opened): #
- [ ] Schema version bumped, with `docs/schema.md` updated
- [ ] Adds/updates a test in `test/privacy/`

### If this adds a new runtime dependency

- [ ] Written justification included below (what it does, why the
      existing stack — commander/vitest — can't do it, what it adds to
      the supply-chain surface)

Closes #42 

### Docs and changelog

- [x] `CHANGELOG.md` entry added under `[Unreleased]` (if user-facing)
- [ ] Relevant doc in `docs/` added or updated, in English

## Additional context

This change updates the EOF error messages for `promptConfirmUpload` and `promptPrivateLabel` to include the corresponding CLI flags, and updates the existing prompt tests to assert the new messages.