### PR TITLE
fix: detect package.json dependencies for Tier1 matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ always bump at least minor; breaking schema changes bump major.
 ## [Unreleased]
 
 ### Fixed
+- Detect package additions from `package.json` dependency blocks (`dependencies`, `devDependencies`, and `peerDependencies`) as Tier 1 evidence using the existing package signature map.
 - Map the `prisma` and `wrangler` packages to their existing taxonomy slugs, closing package detection gaps.
 - Fix the author identity prompt showing "1 commits" instead of "1 commit" when a single commit is found.
 - Improved non-interactive prompt errors by adding actionable guidance to use `--author <email>` and `--yes` when author identity selection or authorization confirmation cannot be completed because input is unavailable.

--- a/docs/signatures.md
+++ b/docs/signatures.md
@@ -14,16 +14,25 @@ in `taxonomy.json`.
 
 For most technology, "this commit imported package X" is already enough to
 say "this commit used X." `src/import-detect.ts` parses added lines for
-import statements across ten language families (JS/TS `import`/`require`/
-dynamic `import()`, Python `import`/`from`, Go `import` including blocks,
-Ruby `require`/Gemfile `gem`, PHP `composer.json`'s `require` and, more
-loosely, `use` namespace statements — see "PHP scope" below; Rust `use`/
-Cargo.toml, Java `import`, Kotlin `import`, C# `using`/.csproj, Swift
-`import`/Package.swift — see "Rust, JVM, and C# scope" and "Swift scope"
-below), normalizes each to a package name (`stripe/webhooks` → `stripe`,
-`@org/pkg/sub` → `@org/pkg`, a Go path's trailing `/v9` stripped, …), and
-looks it up in `signatures/package-map.json` — a flat
+import statements and dependency manifests across ten language families
+(JS/TS `import`/`require`/dynamic `import()` and `package.json`
+`dependencies`/`devDependencies`/`peerDependencies` blocks, Python
+`import`/`from`, Go `import` including blocks, Ruby `require`/Gemfile
+`gem`, PHP `composer.json`'s `require` and, more loosely, `use`
+namespace statements — see "PHP scope" below; Rust `use`/Cargo.toml,
+Java `import`, Kotlin `import`, C# `using`/.csproj, Swift
+`import`/`Package.swift` — see "Rust, JVM, and C# scope" and "Swift
+scope" below), normalizes each to a package name (`stripe/webhooks` →
+`stripe`, `@org/pkg/sub` → `@org/pkg`, a Go path's trailing `/v9`
+stripped, …), and looks it up in `signatures/package-map.json` — a flat
 `{"package-name": "taxonomy-slug"}` map, 600+ entries.
+
+`package.json` dependency detection is intentionally conservative:
+dependency entries are only attributed when the relevant dependency block
+header (`dependencies`, `devDependencies`, or `peerDependencies`) is
+present in the added diff lines. Without that context, a standalone
+`"package": "version"` entry cannot be safely attributed and is treated
+as a documented miss rather than guessed evidence.
 
 Deliberately regex-based, not a real parser per language (a dependency per
 language is a supply-chain surface CLAUDE.md's policy doesn't allow without

--- a/src/import-detect.ts
+++ b/src/import-detect.ts
@@ -172,7 +172,11 @@ function extractJsImports(text: string): string[] {
 
 const PACKAGE_JSON_DEPS_HEADER = /^"(dependencies|devDependencies|peerDependencies)"\s*:\s*\{$/;
 const PACKAGE_JSON_DEP_LINE = /^"([^"]+)"\s*:/;
-
+// package.json is parsed from added diff lines only. A dependency block
+// header (`dependencies`, `devDependencies`, or `peerDependencies`) must be
+// present in the added lines before scanning its contents; otherwise a
+// standalone `"package": "version"` entry cannot be safely attributed and is
+// treated as a documented miss rather than guessed evidence.
 function extractPackageJson(text: string): string[] {
   const found: string[] = [];
   let dependencyDepth = 0;
@@ -548,8 +552,9 @@ export function extractImportedPackages(addedLines: string, filePath: string): s
   const isComposerJson = language === "php" && /composer\.json$/i.test(filePath);
   const isCargoToml = language === "rust" && /cargo\.toml$/i.test(filePath);
   const isCsproj = language === "csharp" && /\.csproj$/i.test(filePath);
+  const isPackageJson = language === "js" && /package\.json$/i.test(filePath);
   const text =
-    isComposerJson || isCargoToml || isCsproj ? addedLines : stripNonCodeRegions(addedLines);
+    isComposerJson || isCargoToml || isCsproj || isPackageJson ? addedLines : stripNonCodeRegions(addedLines);
   switch (language) {
     case "js":
       return extractJs(text, filePath);

--- a/src/import-detect.ts
+++ b/src/import-detect.ts
@@ -34,6 +34,7 @@ function languageForPath(filePath: string): ImportLanguage | null {
   if (ext === ".go") return "go";
   if (ext === ".rb" || lower.endsWith("/gemfile") || lower === "gemfile") return "ruby";
   if (ext === ".php" || lower.endsWith("/composer.json") || lower === "composer.json") return "php";
+  if (lower.endsWith("/package.json") || lower === "package.json") return "js";
   if (ext === ".rs" || lower.endsWith("/cargo.toml") || lower === "cargo.toml") return "rust";
   if (ext === ".java") return "java";
   if (ext === ".kt" || ext === ".kts") return "kotlin";
@@ -126,7 +127,7 @@ function normalizeJs(raw: string): string {
   return raw.split("/")[0];
 }
 
-function extractJs(text: string): string[] {
+function extractJsImports(text: string): string[] {
   const found: string[] = [];
   // import ... from "pkg" / export ... from "pkg" (also covers `export * from`,
   // `export { x } from`, and multi-line named-import lists via [\s\S]*?).
@@ -167,6 +168,51 @@ function extractJs(text: string): string[] {
     found.push(normalizeJs(m[1]));
   }
   return found;
+}
+
+const PACKAGE_JSON_DEPS_HEADER = /^"(dependencies|devDependencies|peerDependencies)"\s*:\s*\{$/;
+const PACKAGE_JSON_DEP_LINE = /^"([^"]+)"\s*:/;
+
+function extractPackageJson(text: string): string[] {
+  const found: string[] = [];
+  let dependencyDepth = 0;
+  let scanningDependencies = false;
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const rawLine = lines[i];
+    if (isCommentLine(rawLine)) continue;
+    const line = rawLine.trim();
+    if (PACKAGE_JSON_DEPS_HEADER.test(line)) {
+      scanningDependencies = true;
+      dependencyDepth = 1;
+      continue;
+    }
+
+    if (!scanningDependencies) continue;
+
+    if (line.includes("{")) {
+      dependencyDepth++;
+    }
+    if (line.includes("}")) {
+      dependencyDepth--;
+
+      if (dependencyDepth === 0) {
+        scanningDependencies = false;
+      }
+      continue;
+    }
+    const dep = PACKAGE_JSON_DEP_LINE.exec(line);
+    if (dep) {
+      found.push(dep[1]);
+    }
+  }
+
+  return found;
+}
+function extractJs(text: string, filePath: string): string[] {
+    return /package\.json$/i.test(filePath)
+    ? extractPackageJson(text)
+    : extractJsImports(text);
 }
 
 function extractPython(text: string): string[] {
@@ -506,7 +552,7 @@ export function extractImportedPackages(addedLines: string, filePath: string): s
     isComposerJson || isCargoToml || isCsproj ? addedLines : stripNonCodeRegions(addedLines);
   switch (language) {
     case "js":
-      return extractJs(text);
+      return extractJs(text, filePath);
     case "python":
       return extractPython(text);
     case "go":

--- a/test/import-detect.test.ts
+++ b/test/import-detect.test.ts
@@ -425,3 +425,41 @@ describe("extractImportedPackages — MCP SDKs (ai/mcp package-map keys)", () =>
     ).toEqual(["modelcontextprotocol"]);
   });
 });
+
+describe("extractImportedPackages — package.json", () => {
+  it("extracts dependencies from package.json", () => {
+    const diff = [
+      '"dependencies": {',
+      '"@prisma/client": "^6"',
+      "}",
+    ].join("\n");
+
+    expect(
+      extractImportedPackages(diff, "package.json")
+    ).toEqual(["@prisma/client"]);
+  });
+
+  it("extracts devDependencies from package.json", () => {
+    const diff = [
+      '"devDependencies": {',
+      '"vitest": "^2.0.0"',
+      "}",
+    ].join("\n");
+
+    expect(
+      extractImportedPackages(diff, "package.json")
+    ).toEqual(["vitest"]);
+  });
+
+  it("does not extract package names from scripts", () => {
+    const diff = [
+      '"scripts": {',
+      '"test": "vitest"',
+      "}",
+    ].join("\n");
+
+    expect(
+      extractImportedPackages(diff, "package.json")
+    ).toEqual([]);
+  });
+});

--- a/test/import-detect.test.ts
+++ b/test/import-detect.test.ts
@@ -451,6 +451,22 @@ describe("extractImportedPackages — package.json", () => {
     ).toEqual(["vitest"]);
   });
 
+  it("extracts dependencies even when scripts contain glob patterns", () => {
+    const diff = [
+      '"scripts": {',
+      '"clean": "rm -rf dist/*",',
+      '"lint": "eslint src/**/*.ts"',
+      "},",
+      '"dependencies": {',
+      '  "@prisma/client": "^6"',
+      "}",
+    ].join("\n");
+
+    expect(
+      extractImportedPackages(diff, "package.json")
+    ).toEqual(["@prisma/client"]);
+  });
+
   it("does not extract package names from scripts", () => {
     const diff = [
       '"scripts": {',
@@ -459,7 +475,7 @@ describe("extractImportedPackages — package.json", () => {
     ].join("\n");
 
     expect(
-      extractImportedPackages(diff, "package.json")
+          extractImportedPackages(diff, "package.json")
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

This PR extends Tier 1 package detection to include `package.json` dependency changes.

- Previously, package evidence was primarily detected through import statements in source files. This change allows dependency additions in `package.json` `dependencies`, `devDependencies`, and `peerDependencies` blocks to produce evidence using the existing `signatures/package-map.json` vocabulary.
- The implementation reuses the existing package mapping flow, so only already-known packages can produce matches. No new slugs or signatures are introduced.
- This makes credentials more complete and verifiable by capturing developer intent expressed through dependency additions, while keeping the existing closed vocabulary and attribution model intact.

Closes #44 

## Checklist

- [x] Tests pass locally (`npm test`)
- [x] `npm run typecheck` passes

### If this adds or changes a detection signature

- [x] Includes at least one positive fixture and one negative fixture
      (the negative fixture is a genuine near-miss, not unrelated text)
- [x] The slug used already exists in `taxonomy.json` — if it's new, that's
      a **separate** PR with a rationale, linked here: #

### If this touches WHAT data leaves the machine, or WHERE it's sent

- [x] Not applicable — this change only affects local detection logic and does not change data boundaries.
- [x] Schema version unchanged
- [x] No privacy test updates required

### If this adds a new runtime dependency

- [x] Not applicable — no new runtime dependencies added.

### Docs and changelog

- [x] `CHANGELOG.md` entry added under `[Unreleased]` (if user-facing)
- [x] No additional docs required; existing detection documentation remains accurate.

## Additional context

Added `package.json` manifest detection through the existing JS extraction path.

The extractor distinguishes between:
- Source files (`.js`, `.ts`, etc.) → import/require detection
- `package.json` → dependency block detection

Added coverage for:
- Positive case: mapped packages added through dependency blocks are extracted.
- Negative case: package names appearing outside dependency blocks (for example, script entries) are ignored.

Existing import detection behavior remains unchanged.