### PR TITLE
Zod map and storybook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ always bump at least minor; breaking schema changes bump major.
 
 ## [Unreleased]
 
+### Added
+- Map the `zod` npm import to `validation/zod` (Tier 1).
+- Add Tier 2 signature for Storybook (`frontend/storybook`): detects
+  `.storybook/main.*` and `.storybook/preview.*` config files,
+  `*.stories.*` story files, and `@storybook/*` scoped imports.
+
 ### Changed
 - Show a tip in the TTY summary when no commits are cryptographically signed, with guidance for enabling commit signing.
 
@@ -25,10 +31,6 @@ always bump at least minor; breaking schema changes bump major.
   [docs/identity-selection-memory.md](docs/identity-selection-memory.md).
 - Add `validation/zod` to the closed skill taxonomy for Zod work.
 - Add `frontend/storybook` to the closed skill taxonomy for Storybook work.
-- Map the `zod` npm import to `validation/zod` (Tier 1).
-- Add Tier 2 signature for Storybook (`frontend/storybook`): detects
-  `.storybook/main.*` and `.storybook/preview.*` config files,
-  `*.stories.*` story files, and `@storybook/*` scoped imports.
 
 ### Fixed
 - Detect package additions from `package.json` dependency blocks (`dependencies`, `devDependencies`, and `peerDependencies`) as Tier 1 evidence using the existing package signature map.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ always bump at least minor; breaking schema changes bump major.
   [docs/identity-selection-memory.md](docs/identity-selection-memory.md).
 - Add `validation/zod` to the closed skill taxonomy for Zod work.
 - Add `frontend/storybook` to the closed skill taxonomy for Storybook work.
+- Map the `zod` npm import to `validation/zod` (Tier 1).
+- Add Tier 2 signature for Storybook (`frontend/storybook`): detects
+  `.storybook/main.*` and `.storybook/preview.*` config files,
+  `*.stories.*` story files, and `@storybook/*` scoped imports.
 
 ### Fixed
 - Detect package additions from `package.json` dependency blocks (`dependencies`, `devDependencies`, and `peerDependencies`) as Tier 1 evidence using the existing package signature map.

--- a/signatures/frontend/storybook.json
+++ b/signatures/frontend/storybook.json
@@ -1,0 +1,33 @@
+{
+  "slug": "frontend/storybook",
+  "importPatterns": [
+    "from\\s+[\"']@storybook/"
+  ],
+  "apiPatterns": [],
+  "configFilePatterns": [
+    "(^|/)\\.storybook/(main|preview)\\.(js|jsx|ts|tsx|cjs|mjs)$",
+    "\\.stories\\.(js|jsx|ts|tsx)$"
+  ],
+  "fixtures": {
+    "positive": [
+      {
+        "path": ".storybook/main.ts",
+        "diff": "import type { StorybookConfig } from '@storybook/react-vite';\nconst config: StorybookConfig = { addons: [\"@storybook/addon-docs\"] };\nexport default config;"
+      },
+      {
+        "path": ".storybook/preview.tsx",
+        "diff": "import type { Preview } from '@storybook/react-vite';\nimport { ThemeProvider } from '../src/theme/ThemeProvider';\nconst preview: Preview = { parameters: {} };\nexport default preview;"
+      },
+      {
+        "path": "src/components/ui/Button.stories.tsx",
+        "diff": "import type { Meta, StoryObj } from '@storybook/react';\nimport { Button } from './Button';\nconst meta: Meta<typeof Button> = { title: 'UI Components/Button' };\nexport default meta;"
+      }
+    ],
+    "negative": [
+      {
+        "path": "README.md",
+        "diff": "We considered Storybook for our component library but decided to document components inline instead."
+      }
+    ]
+  }
+}

--- a/signatures/frontend/storybook.json
+++ b/signatures/frontend/storybook.json
@@ -5,8 +5,8 @@
   ],
   "apiPatterns": [],
   "configFilePatterns": [
-    "(^|/)\\.storybook/(main|preview)\\.(js|jsx|ts|tsx|cjs|mjs)$",
-    "\\.stories\\.(js|jsx|ts|tsx)$"
+    "(^|/)\\.storybook/(main|preview)\\.(js|jsx|ts|tsx|cjs|mjs|mts|cts)$",
+    "\\.stories\\.(js|jsx|ts|tsx|mdx)$"
   ],
   "fixtures": {
     "positive": [
@@ -21,6 +21,14 @@
       {
         "path": "src/components/ui/Button.stories.tsx",
         "diff": "import type { Meta, StoryObj } from '@storybook/react';\nimport { Button } from './Button';\nconst meta: Meta<typeof Button> = { title: 'UI Components/Button' };\nexport default meta;"
+      },
+      {
+        "path": ".storybook/main.mts",
+        "diff": "import type { StorybookConfig } from '@storybook/react-vite';\nconst config: StorybookConfig = { addons: [\"@storybook/addon-docs\"] };\nexport default config;"
+      },
+      {
+        "path": "src/components/ui/Button.stories.mdx",
+        "diff": "import { Meta, Story } from '@storybook/blocks';\nimport { Button } from './Button';\n\n<Meta title=\"UI Components/Button\" component={Button} />"
       }
     ],
     "negative": [

--- a/signatures/package-map.json
+++ b/signatures/package-map.json
@@ -616,6 +616,7 @@
     "nimble": "testing/quick-nimble",
     "swinject": "backend/swinject",
     "promisekit": "frontend/promisekit",
-    "firebasefirestore": "db/firebase-firestore"
+    "firebasefirestore": "db/firebase-firestore",
+    "zod": "validation/zod"
   }
 }


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

- Add a Tier 1 signatures/package-map.json entry mapping the zod import to `validation/zod`.
- Single-entry mapping — Zod is npm/TS-only with one unambiguous import name, so no additional ecosystem variants apply.
- Add a Tier 2 signature at signatures/frontend/storybook.json mapping to `frontend/storybook`.
- Detects three independent surfaces, any one sufficient: `.storybook/main.*` and `.storybook/preview.*` config files, `*.stories.*` story files, and `@storybook/*` scoped imports (covers all framework variants — React, Vue, Angular — and addons via prefix match).

Rationale: Zod is a Tier 1 signature because it has a single, unambiguous package name (`zod`) with no ecosystem variants or competing libraries. 

Storybook has no single unambiguous import, so it is a Tier 2 signature. Instead, detection uses three independent signals: `.storybook/main.*` or `.storybook/preview.*` config files, `*.stories.*` files, and `@storybook/*` imports, which naturally cover all framework variants and addons. The patterns were validated against current Storybook v10 to ensure detection is accurate.


<!--
Every contribution should make the credential more solid, trustworthy, or
verifiable (see CONTRIBUTING.md). Explain what this change does and how it
moves that needle.
-->

## Checklist

- [X] Tests pass locally (`npm test`)
- [X] `npm run typecheck` passes

### If this adds or changes a detection signature

- [X] Includes at least one positive fixture and one negative fixture
      (the negative fixture is a genuine near-miss, not unrelated text)
- [X] The slug used already exists in `taxonomy.json` — if it's new, that's
      a **separate** PR with a rationale, linked here: #40 

### Docs and changelog

- [X] `CHANGELOG.md` entry added under `[Unreleased]` (if user-facing)
- [X] Relevant doc in `docs/` added or updated, in English

## Additional context

<!-- Anything a reviewer needs that isn't obvious from the diff. -->
