### PR TITLE
Add signed commit guidance and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ always bump at least minor; breaking schema changes bump major.
 
 ## [Unreleased]
 
+### Changed
+- Show a tip in the TTY summary when no commits are cryptographically signed, with guidance for enabling commit signing.
+
 ## [0.7.0] - 2026-07-28
+
 ### Added
 - `scan` and `submit` now remember the per-repo author-identity selection and
   prefill it on the next run against the same repo — a repeat run confirms
@@ -29,8 +33,6 @@ always bump at least minor; breaking schema changes bump major.
 - Improved non-interactive submit prompt errors by adding actionable guidance to use `--confirm-upload` and `--label` when upload confirmation or private label input cannot be completed because input is unavailable.
 
 ### Changed
-- Show a tip in the TTY summary when no commits are cryptographically 
-  signed, with guidance for enabling commit signing.
 - `submit` no longer repeats `scan`'s "Continue locally? (Y/n)" question for
   a connectable-repo remote — it still prints the same warning, but the real
   protection against a public repo on `submit` is its network visibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ always bump at least minor; breaking schema changes bump major.
 
 ## [Unreleased]
 
-### Fixed
-- Show a one-time tip in the TTY summary when no commits are cryptographically signed, with guidance for enabling commit signing.
-
 ## [0.7.0] - 2026-07-28
 ### Added
 - `scan` and `submit` now remember the per-repo author-identity selection and
@@ -32,6 +29,8 @@ always bump at least minor; breaking schema changes bump major.
 - Improved non-interactive submit prompt errors by adding actionable guidance to use `--confirm-upload` and `--label` when upload confirmation or private label input cannot be completed because input is unavailable.
 
 ### Changed
+- Show a tip in the TTY summary when no commits are cryptographically 
+  signed, with guidance for enabling commit signing.
 - `submit` no longer repeats `scan`'s "Continue locally? (Y/n)" question for
   a connectable-repo remote — it still prints the same warning, but the real
   protection against a public repo on `submit` is its network visibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ always bump at least minor; breaking schema changes bump major.
 
 ## [Unreleased]
 
-## [0.7.0] - 2026-07-28
+### Fixed
+- Show a one-time tip in the TTY summary when no commits are cryptographically signed, with guidance for enabling commit signing.
 
+## [0.7.0] - 2026-07-28
 ### Added
 - `scan` and `submit` now remember the per-repo author-identity selection and
   prefill it on the next run against the same repo — a repeat run confirms

--- a/docs/signed-commits.md
+++ b/docs/signed-commits.md
@@ -17,4 +17,8 @@ To enable SSH commit signing:
 ```bash
 git config --global gpg.format ssh
 git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
 ```
+
+GitHub displays commits as **Verified** after you upload your public SSH
+key as a signing key to your GitHub account.

--- a/docs/signed-commits.md
+++ b/docs/signed-commits.md
@@ -1,0 +1,20 @@
+# Signed commits
+
+Git commits are normally attributed through the author identity configured
+on the commit, usually an email address. That identity is useful evidence,
+but an email address alone can be claimed or impersonated.
+
+Signed commits add a cryptographic signature to the commit. This allows
+verifiers to attribute work through possession of a signing key rather than
+only a claimable email address.
+
+Unsigned commits remain valid evidence. Signing does not replace existing
+credential evidence; it strengthens attribution by adding cryptographic
+proof of authorship.
+
+To enable SSH commit signing:
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+```

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -538,7 +538,7 @@ export function formatSummary(bundle: Bundle, opts: FormatSummaryOptions = {}): 
   );
   if (bundle.signed.ratio === 0) {
     lines.push(
-      `  ${colors.DIM}Tip: signing future commits adds a stronger identity anchor to your attestation.${colors.RESET}`
+     `  ${colors.DIM}Tip: none of your commits are signed. Signed commits make your future work cryptographically attributable: https://docs.github.com/en/authentication/managing-commit-signature-verification${colors.RESET}`
     );
   }
   lines.push("");

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -538,7 +538,7 @@ export function formatSummary(bundle: Bundle, opts: FormatSummaryOptions = {}): 
   );
   if (bundle.signed.ratio === 0) {
     lines.push(
-     `  ${colors.DIM}Tip: none of your commits are signed. Signed commits make your future work cryptographically attributable: https://docs.github.com/en/authentication/managing-commit-signature-verification${colors.RESET}`
+      `  ${colors.DIM}Tip: none of your commits are signed. Signed commits make your future work cryptographically attributable: https://docs.github.com/en/authentication/managing-commit-signature-verification${colors.RESET}`
     );
   }
   lines.push("");

--- a/test/scan-command.test.ts
+++ b/test/scan-command.test.ts
@@ -378,9 +378,7 @@ describe("executeScanCommand", () => {
       isTTY: true,
     });
 
-    expect(logs[0]).toContain(
-      "Tip: signing future commits adds a stronger identity anchor to your attestation."
-    );
+    expect(logs[0]).toContain("Tip: none of your commits are signed.");
   });
 
   it("omits the signing tip when at least one commit is signed", async () => {

--- a/test/summary.test.ts
+++ b/test/summary.test.ts
@@ -84,12 +84,12 @@ describe("formatSummary", () => {
 
   it("shows the signing tip when signed ratio is 0%", () => {
     const text = stripAnsi(formatSummary(baseBundle({ signed: { count: 0, ratio: 0 } })));
-    expect(text).toContain("Tip: signing future commits adds a stronger identity anchor to your attestation.");
+    expect(text).toContain("Tip: none of your commits are signed.");
   });
 
   it("omits the signing tip when signed ratio is above 0%", () => {
-    const text = stripAnsi(formatSummary(baseBundle()));
-    expect(text).not.toContain("Tip: signing future commits");
+    const text = stripAnsi(formatSummary(baseBundle({ signed: { count: 1, ratio: 0.5 } })));
+    expect(text).not.toContain("Tip: none of your commits are signed.");
   });
 
   it("omits the COMMITS BY HOUR/WEEKDAY histogram sections by default (moved behind --details in phase 2)", () => {


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

This PR encourages stronger cryptographic attribution without changing how credentials are evaluated or what data leaves the machine.

When a scan is run in a TTY and none of the user's commits are signed, the summary now displays a single, non-intrusive tip linking to GitHub's commit signing documentation. Unsigned commits remain valid evidence; the message simply explains that signed commits strengthen attribution by proving control of a signing key rather than relying only on a claimable email address.

This PR also adds `docs/signed-commits.md`, explaining why commit signing strengthens a credential and providing the minimal SSH signing setup. Tests have been added to verify that the tip is shown only when the signed commit ratio is `0%` and omitted otherwise.

Closes #47 

## Checklist

- [x] Tests pass locally (`npm test`)
- [x] `npm run typecheck` passes

### If this adds or changes a detection signature

- [ ] Includes at least one positive fixture and one negative fixture
      (the negative fixture is a genuine near-miss, not unrelated text)
- [ ] The slug used already exists in `taxonomy.json` — if it's new, that's
      a **separate** PR with a rationale, linked here: #

### If this touches WHAT data leaves the machine, or WHERE it's sent

- [ ] Links the prior "Data boundary change" discussion issue (required
      before this PR was opened): #
- [ ] Schema version bumped, with `docs/schema.md` updated
- [ ] Adds/updates a test in `test/privacy/`

### If this adds a new runtime dependency

- [ ] Written justification included below (what it does, why the
      existing stack — commander/vitest — can't do it, what it adds to
      the supply-chain surface)

### Docs and changelog

- [x] `CHANGELOG.md` entry added under `[Unreleased]` (if user-facing)
- [x] Relevant doc in `docs/` added or updated, in English

## Additional context

- The signing tip is displayed only for interactive TTY output when the signed commit ratio is `0%`.
- Piped output and `--json` output remain unchanged.
- No runtime dependencies were added.