### PR TITLE
Document global install conflict for alias packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ always bump at least minor; breaking schema changes bump major.
 
 ### Changed
 - Show a tip in the TTY summary when no commits are cryptographically signed, with guidance for enabling commit signing.
+- Document the global install conflict between `redential` and `@redential/cli`, with guidance for updating or switching between them.
 
 ## [0.7.0] - 2026-07-28
 

--- a/packages/redential-cli/README.md
+++ b/packages/redential-cli/README.md
@@ -12,6 +12,18 @@ npm install -g redential
 npm install -g @redential/cli
 ```
 
+**Already have `@redential/cli` installed globally?**
+
+`redential` and `@redential/cli` both install the same `redential`
+executable and cannot be installed globally at the same time. Either
+update the scoped package:
+
+```bash
+npm install -g @redential/cli@latest
+```
+
+or uninstall it before installing `redential`.
+
 Real package, source code, and provenance:
 [`@redential/cli`](https://www.npmjs.com/package/@redential/cli) ·
 [github.com/Redential/redential-cli](https://github.com/Redential/redential-cli).

--- a/packages/redential/README.md
+++ b/packages/redential/README.md
@@ -10,6 +10,18 @@ The real package, source code, and provenance all live at
 — this package is just a launcher that depends on it and forwards every
 command.
 
+**Already have `@redential/cli` installed globally?**
+
+`redential` and `@redential/cli` both install the same `redential`
+executable and cannot be installed globally at the same time. Either
+update the scoped package:
+
+```bash
+npm install -g @redential/cli@latest
+```
+
+or uninstall it before installing `redential`.
+
 ```bash
 npx redential scan
 ```


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

This PR documents the global installation conflict between the `redential`
alias package and the canonical `@redential/cli` package. Since both
packages install the same `redential` executable, npm correctly prevents
them from being installed globally at the same time.

The updated documentation explains how users can either update their
existing `@redential/cli` installation or uninstall it before installing
the `redential` alias, reducing confusion while keeping the installation
experience clear and trustworthy.

Closes #23 

## Checklist

- [x] Tests pass locally (`npm test`)
- [x] `npm run typecheck` passes

### If this adds or changes a detection signature

- [ ] Includes at least one positive fixture and one negative fixture
      (the negative fixture is a genuine near-miss, not unrelated text)
- [ ] The slug used already exists in `taxonomy.json` — if it's new, that's
      a **separate** PR with a rationale, linked here: #

### If this touches WHAT data leaves the machine, or WHERE it's sent

- [ ] Links the prior "Data boundary change" discussion issue (required
      before this PR was opened): #
- [ ] Schema version bumped, with `docs/schema.md` updated
- [ ] Adds/updates a test in `test/privacy/`

### If this adds a new runtime dependency

- [ ] Written justification included below (what it does, why the
      existing stack — commander/vitest — can't do it, what it adds to
      the supply-chain surface)

### Docs and changelog

- [x] `CHANGELOG.md` entry added under `[Unreleased]` (if user-facing)
- [x] Relevant doc in `docs/` added or updated, in English

## Additional context

This is a documentation-only change. No runtime behavior or package
functionality has changed.