### PR TITLE
Taxonomy 1.8.0: auth flow slugs (session, oauth, jwt-refresh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ always bump at least minor; breaking schema changes bump major.
 - Add Tier 2 signature for Storybook (`frontend/storybook`): detects
   `.storybook/main.*` and `.storybook/preview.*` config files,
   `*.stories.*` story files, and `@storybook/*` scoped imports.
+- Add `auth/session-flow`, `auth/oauth-flow`, and `auth/jwt-refresh-flow`
+  to the closed skill taxonomy (taxonomy 1.8.0, per the auth-flows spec
+  in #5).
 
 ### Changed
 - Show a tip in the TTY summary when no commits are cryptographically signed, with guidance for enabling commit signing.

--- a/taxonomy.json
+++ b/taxonomy.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Closed public vocabulary of skill slugs. This file is the ONLY source of valid values for detected_skills[].slug in the bundle: a slug not listed here makes the bundle invalid. Detection maps signatures/*.json matches to these slugs — deterministically, locally, with zero network calls. Adding a slug requires a PR to this file (and a signature definition); slugs are never hardcoded in the CLI. Placeholder set, to be expanded.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "skills": [
     { "slug": "auth/supabase-auth", "label": "Supabase Auth" },
     { "slug": "auth/nextauth", "label": "NextAuth / Auth.js" },
@@ -216,6 +216,9 @@
     { "slug": "payments/mercadopago-flow", "label": "Mercado Pago payment flow" },
     { "slug": "payments/lemonsqueezy-webhook-flow", "label": "Lemon Squeezy webhook flow" },
     { "slug": "payments/paddle-webhook-flow", "label": "Paddle webhook flow" },
+    { "slug": "auth/session-flow", "label": "Session auth flow" },
+    { "slug": "auth/oauth-flow", "label": "OAuth login flow" },
+    { "slug": "auth/jwt-refresh-flow", "label": "JWT refresh flow" },
     { "slug": "validation/zod", "label": "Zod" },
     { "slug": "frontend/storybook", "label": "Storybook" }
   ]


### PR DESCRIPTION
Per the spec in #5. Slug-only, no detection logic — implementation PR follows and is stacked on this branch.

  Note: the issue says 1.6.0 → 1.7.0, but #40 already took 1.7.0, so this is 1.7.0 → 1.8.0.