### PR TITLE
ci: update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
         node-version: [20, 22]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
@@ -52,9 +52,9 @@ jobs:
   huge-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: "npm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
           # provenance requires publishing through a registry that supports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ always bump at least minor; breaking schema changes bump major.
 ### Changed
 - Show a tip in the TTY summary when no commits are cryptographically signed, with guidance for enabling commit signing.
 - Document the global install conflict between `redential` and `@redential/cli`, with guidance for updating or switching between them.
+- Bump the checkout and setup-node GitHub Actions to their current v7 majors so CI uses Node 24-compatible action runtimes.
 
 ## [0.7.0] - 2026-07-28
 


### PR DESCRIPTION
Closes #4

## What changed

- Updated `actions/checkout` from `v4` to `v7` in `ci.yml` and `release.yml`.
- Updated `actions/setup-node` from `v4` to `v7` in both workflows.
- Added the required Unreleased changelog entry.

The existing OS and Node matrix is unchanged. This removes the Node 20 action-runtime warning while keeping the workflow jobs and release behavior intact.

## Validation

- Parsed both workflow files successfully with PyYAML.
- `npm run typecheck`
- `npm run build`
- `npm test -- --pool=threads --fileParallelism=false --maxWorkers=1` (48 files, 744 tests passed)

The first default-parallel Windows run hit temporary-repository cleanup locks and timeouts; the serial rerun passed the full suite without code changes.
