### PR TITLE
Document exit-code contract for scripting and CI (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ always bump at least minor; breaking schema changes bump major.
 ## [Unreleased]
 
 ### Added
+- Document the CLI exit-code contract for scripting and CI (`docs/exit-codes.md`, #29).
 - `redential --version` (and `-V`) prints the CLI version. Program
   construction moved into a testable `createProgram()` to cover it.
 - Map the `zod` npm import to `validation/zod` (Tier 1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ always bump at least minor; breaking schema changes bump major.
 
 ### Added
 - Document the CLI exit-code contract for scripting and CI (`docs/exit-codes.md`, #29).
-- Add a "Docs first (CLI contract)" section to `CONTRIBUTING.md`.
 - `redential --version` (and `-V`) prints the CLI version. Program
   construction moved into a testable `createProgram()` to cover it.
 - Map the `zod` npm import to `validation/zod` (Tier 1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ always bump at least minor; breaking schema changes bump major.
 
 ### Added
 - Document the CLI exit-code contract for scripting and CI (`docs/exit-codes.md`, #29).
+- Add a "Docs first (CLI contract)" section to `CONTRIBUTING.md`.
 - `redential --version` (and `-V`) prints the CLI version. Program
   construction moved into a testable `createProgram()` to cover it.
 - Map the `zod` npm import to `validation/zod` (Tier 1).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,24 @@ entries get agreed on before code exists. PRs in these areas without a
 prior issue get closed regardless of code quality — sorry, the trust
 contract comes first.
 
+## Docs first (CLI contract)
+
+The privacy rule guards **what leaves the machine**. This section guards
+**what operators and CI can rely on**: exit codes, flags, stdout vs stderr,
+and any behavior a script might parse.
+
+- **Document before you change.** A PR that changes user-visible CLI
+  semantics must update the relevant `docs/` page (or add one), link it from
+  README's [Docs](README.md#docs) list when it's a new top-level page, and
+  add a `CHANGELOG.md` line under `[Unreleased]` in the **same PR** as the
+  code. Don't merge behavior without the doc.
+- **Docs-only is fine.** Issues that only ask to describe current behavior
+  (for example exit-code tables verified against `src/program.ts`) ship as
+  documentation PRs with no code changes.
+- **Cross-link, don't scatter.** One canonical page per contract (see
+  [docs/exit-codes.md](docs/exit-codes.md) for process outcome); other docs
+  link to it instead of duplicating tables.
+
 Everything else (bug fixes, performance, DX, docs, tests, detection
 signatures): PRs welcome directly.
 
@@ -131,6 +149,8 @@ before opening the PR.
 - Any change to WHAT data leaves the machine requires, in order: a prior
   discussion issue, a schema version bump, and an entry in
   `docs/schema.md` and `CHANGELOG.md` — see "The privacy rule" above.
+- Any change to CLI scripting semantics (exit codes, flags, output
+  channels) follows "Docs first (CLI contract)" above.
 - English only, in code comments and in docs — this is an international,
   public repo.
 - Tests use vitest. Fixtures are git repos created programmatically in a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,24 +26,6 @@ entries get agreed on before code exists. PRs in these areas without a
 prior issue get closed regardless of code quality — sorry, the trust
 contract comes first.
 
-## Docs first (CLI contract)
-
-The privacy rule guards **what leaves the machine**. This section guards
-**what operators and CI can rely on**: exit codes, flags, stdout vs stderr,
-and any behavior a script might parse.
-
-- **Document before you change.** A PR that changes user-visible CLI
-  semantics must update the relevant `docs/` page (or add one), link it from
-  README's [Docs](README.md#docs) list when it's a new top-level page, and
-  add a `CHANGELOG.md` line under `[Unreleased]` in the **same PR** as the
-  code. Don't merge behavior without the doc.
-- **Docs-only is fine.** Issues that only ask to describe current behavior
-  (for example exit-code tables verified against `src/program.ts`) ship as
-  documentation PRs with no code changes.
-- **Cross-link, don't scatter.** One canonical page per contract (see
-  [docs/exit-codes.md](docs/exit-codes.md) for process outcome); other docs
-  link to it instead of duplicating tables.
-
 Everything else (bug fixes, performance, DX, docs, tests, detection
 signatures): PRs welcome directly.
 
@@ -149,8 +131,6 @@ before opening the PR.
 - Any change to WHAT data leaves the machine requires, in order: a prior
   discussion issue, a schema version bump, and an entry in
   `docs/schema.md` and `CHANGELOG.md` — see "The privacy rule" above.
-- Any change to CLI scripting semantics (exit codes, flags, output
-  channels) follows "Docs first (CLI contract)" above.
 - English only, in code comments and in docs — this is an international,
   public repo.
 - Tests use vitest. Fixtures are git repos created programmatically in a

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ and what the provenance attestation actually proves.
 - [docs/principles.md](docs/principles.md) — the six non-negotiable rules
 - [docs/privacy-tests.md](docs/privacy-tests.md) — which test proves which rule
 - [docs/scan.md](docs/scan.md) — full `scan` command reference
+- [docs/exit-codes.md](docs/exit-codes.md) — exit codes for CI and shell scripts
 - [docs/login-submit.md](docs/login-submit.md) — `login`, `submit`, `logout`
 - [docs/identity-selection-memory.md](docs/identity-selection-memory.md) — how `scan`/`submit` remember your per-repo identity selection
 - [docs/private-label.md](docs/private-label.md) — the mandatory private label: what it is, why it travels outside the bundle

--- a/docs/exit-codes.md
+++ b/docs/exit-codes.md
@@ -1,0 +1,78 @@
+# Exit codes
+
+Redential uses a small, scriptable exit-code surface. Every command goes
+through the same top-level handler in `src/program.ts` (`run()`): domain
+failures print `Error: …` on **stderr** and set exit code **1**; everything
+else finishes with exit code **0** (Node's default when `process.exitCode` is
+never set).
+
+## Summary
+
+| Code | Meaning |
+| ---- | ------- |
+| **0** | Success — the command completed its work, including intentional no-ops described below. |
+| **1** | Expected failure — a `ScanError`, `AuthError`, `SubmitError`, or `NetworkError` (see [errors](#domain-errors-exit-1)). Commander flag/argument mistakes also exit **1** when `parse()` rejects the invocation. |
+
+Unhandled exceptions (bugs, unexpected I/O failures outside those four error
+types) may exit with a non-zero code that is **not** part of this contract.
+
+## Domain errors (exit 1)
+
+| Error type | Typical causes |
+| ---------- | -------------- |
+| `ScanError` | Invalid repo or git state, missing `--author` / `--yes` in non-interactive mode, validation failures (private label, `--since`, secrets in bundle), unsupported `explain` skill, malformed internal signature files. |
+| `AuthError` | `submit` without a stored session, wrong site URL on stored credentials, login denied/expired/timed out. |
+| `SubmitError` | Upload refused after the remote-visibility gate (confirmed-public repo). |
+| `NetworkError` | Login or submit HTTP failures (unreachable host, non-JSON response, unexpected status) after retries where applicable. |
+
+Messages are sanitized user-facing strings only — never tokens or bundle
+payloads.
+
+## Success with exit 0 (including no-ops)
+
+These paths are deliberate so CI and shell scripts can treat **0** as "nothing
+went wrong," even when no bundle was printed or uploaded:
+
+| Command | Exit 0 when… |
+| ------- | -------------- |
+| `scan` | A bundle was produced (JSON on stdout when piped/`--json`, or the TTY summary otherwise). |
+| `scan` | On a TTY, you answer **n** to "Continue locally?" for a connectable-looking remote — no scan runs ([scan.md](scan.md#how-it-works)). |
+| `submit` | You decline the upload prompt (`Aborted — nothing was uploaded.`) — bundle may have been built and printed, but nothing was sent. |
+| `submit` | Bundle upload succeeded, even if the follow-up private-label request failed (warning on stderr; see [private-label.md](private-label.md)). |
+| `login` / `logout` | Session stored or removed locally. |
+| `status` | Local state printed (always read-only, no network). |
+| `explain` | Explanation printed for a supported skill (spike command). |
+
+A successful `scan` in a pipeline:
+
+```bash
+redential scan --repo . --author you@example.com --yes --json | jq .
+test "${PIPESTATUS[0]}" -eq 0
+```
+
+Non-interactive upload (all consent flags required):
+
+```bash
+redential submit --repo . \
+  --author you@example.com \
+  --yes \
+  --confirm-upload \
+  --label "Acme Corp"
+```
+
+See [login-submit.md](login-submit.md) for the full `login` / `submit` flow.
+
+## Stability
+
+For scripting and CI, treat this table as part of the CLI's public contract:
+
+- **0** means success and **1** means an expected, documented failure class
+  above. Those meanings will not be swapped or narrowed without a **major**
+  semver release.
+- New legitimate success no-ops may be documented in a **minor** release
+  (still exit **0**).
+- New failure modes that should fail closed in automation will continue to use
+  exit **1** via the four domain error types where possible.
+
+Bundle JSON on stdout is versioned separately ([schema](schema.md)); exit
+codes describe process outcome only.

--- a/docs/login-submit.md
+++ b/docs/login-submit.md
@@ -6,7 +6,7 @@ only place the CLI ever does — see [principles.md](principles.md).
 ```bash
 redential login                              # device flow, one time
 redential submit --repo <path>                # interactive: prints the bundle, then asks
-redential submit --author you@x.com --yes --confirm-upload --label "Acme Corp"   # non-interactive
+redential submit --author you@x.com --yes --confirm-upload --label "Acme Corp"   # non-interactive (exit codes: docs/exit-codes.md)
 redential logout                              # delete the stored session
 ```
 
@@ -239,7 +239,8 @@ selection, same authorization-confirmation prompt, same `runScan`. It then:
    failure semantics: this request is never retried, and a failure here
    never triggers a second bundle upload — it only prints a warning
    (naming the label, so it can be set again from the web) and `submit`
-   still exits 0, since the bundle itself is already safely uploaded.
+   still exits 0, since the bundle itself is already safely uploaded (see
+   [exit-codes.md](exit-codes.md)).
 9. Records the upload locally (`last-submission.json`, above) — not part
    of what's sent, just local bookkeeping for a later `scan`'s next-step
    hint. Unlike the version-check notice below, this is not best-effort:

--- a/docs/private-label.md
+++ b/docs/private-label.md
@@ -114,7 +114,7 @@ diverge on what counts as valid:
   this repo (only you will ever see it): `. An invalid answer (empty, too
   long, control characters, or secret-shaped) re-asks, up to 2 retries (3
   attempts total); the final failed attempt raises the specific validation
-  error and aborts — exit 1, **nothing was uploaded**, not even the
+  error and aborts — [exit 1](exit-codes.md), **nothing was uploaded**, not even the
   bundle. This is a deliberate widening of the spec's literal "empty
   answer re-asks" language to cover every validation failure the same way
   (rather than treating an over-long or secret-shaped answer differently

--- a/docs/scan.md
+++ b/docs/scan.md
@@ -49,7 +49,8 @@ skipped.
    suggesting the GitHub App instead. Piped/non-TTY output — and `--json`,
    even on a real TTY — is unaffected: the notice still prints (non-blocking,
    to stderr), but no interactive question is ever asked, the same "warn,
-   never block" behavior every prior release had.
+   never block" behavior every prior release had. For how that choice maps to
+   process exit codes in pipelines, see [exit-codes.md](exit-codes.md).
 2. **Enumerate authors.** `git log` is read locally (`git show`/`git diff`
    never leave the machine) to list distinct author emails and their commit
    counts.
@@ -271,7 +272,8 @@ This only happens on a real TTY with no `--json`. `scan | jq` (or any
 redirected/piped stdout) prints **only** the raw JSON, byte-identical to
 before this summary existed — `--json` forces that same JSON-only behavior
 even on a terminal, for scripts that run interactively but still want
-machine output.
+machine output. Exit codes for piped and `--json` runs are documented in
+[exit-codes.md](exit-codes.md).
 
 ## Huge repositories and `--since`
 


### PR DESCRIPTION
## Summary
- Adds `docs/exit-codes.md`: 0/1 table, domain error mapping, intentional no-op success paths (connectable-repo decline, upload abort, bundle OK + label warning), CI examples, semver stability note.
- Links from README docs list, `scan.md`, `login-submit.md`, and `private-label.md`.
- `CHANGELOG.md` under `[Unreleased]`.

Verified against `src/program.ts` `run()` (post-#56 `createProgram` split).

**Draft** until maintainers are happy with contract wording.

## Test plan
- [ ] Docs read-through for accuracy vs current behavior
- [ ] No code changes — CI should be unchanged

Closes #29