### PR TITLE
taxonomy: add CircleCI slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ always bump at least minor; breaking schema changes bump major.
 ## [Unreleased]
 
 ### Added
+- Add `infra/circleci` to the closed skill taxonomy (#24).
 - Document the CLI exit-code contract for scripting and CI (`docs/exit-codes.md`, #29).
 - `redential --version` (and `-V`) prints the CLI version. Program
   construction moved into a testable `createProgram()` to cover it.

--- a/taxonomy.json
+++ b/taxonomy.json
@@ -1,6 +1,6 @@
 {
   "$comment": "Closed public vocabulary of skill slugs. This file is the ONLY source of valid values for detected_skills[].slug in the bundle: a slug not listed here makes the bundle invalid. Detection maps signatures/*.json matches to these slugs — deterministically, locally, with zero network calls. Adding a slug requires a PR to this file (and a signature definition); slugs are never hardcoded in the CLI. Placeholder set, to be expanded.",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "skills": [
     { "slug": "auth/supabase-auth", "label": "Supabase Auth" },
     { "slug": "auth/nextauth", "label": "NextAuth / Auth.js" },
@@ -84,6 +84,7 @@
     { "slug": "infra/kubernetes", "label": "Kubernetes" },
     { "slug": "infra/terraform", "label": "Terraform" },
     { "slug": "infra/github-actions", "label": "GitHub Actions" },
+    { "slug": "infra/circleci", "label": "CircleCI" },
     { "slug": "infra/aws-sdk", "label": "AWS SDK" },
     { "slug": "infra/pulumi", "label": "Pulumi" },
     { "slug": "infra/ansible", "label": "Ansible" },


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

Adds `infra/circleci` to the closed skill taxonomy and advances the taxonomy version from 1.8.0 to 1.9.0.

CircleCI is a distinct, widely used CI platform whose `.circleci/config.yml` path can provide deterministic local evidence. Adding the slug first keeps the vocabulary review separate from the dependent signature work required by #24.

## Checklist

- [ ] Tests pass locally (`npm test`) — the affected 92-test taxonomy/privacy contract passes; the complete suite timed out locally during Windows git-fixture scans
- [x] `npm run typecheck` passes

### If this adds or changes a detection signature

- [ ] Includes at least one positive fixture and one negative fixture — not applicable to this taxonomy-only PR
- [ ] The slug used already exists in `taxonomy.json` — this PR adds the slug; the signature will be a separate dependent PR

### If this touches WHAT data leaves the machine, or WHERE it's sent

- [x] Links the prior discussion issue: #24
- [ ] Schema version bumped, with `docs/schema.md` updated — not applicable; the bundle schema is unchanged
- [x] Relevant privacy/taxonomy contract tests run

### If this adds a new runtime dependency

- [ ] Written justification included below — not applicable; no dependency changes

### Docs and changelog

- [x] `CHANGELOG.md` entry added under `[Unreleased]`
- [ ] Relevant doc added or updated — not applicable to the vocabulary-only step

## Additional context

Privacy gate: run
- Boundary question: YES — prior issue #24
- `npm run typecheck`: passed
- `npm run build`: passed
- Taxonomy/package-map/privacy contract: 92 tests passed
- Full `npm test`: attempted twice but timed out locally on Windows during git-fixture scanning; CI is expected to run the normal matrix
- Mechanical sweeps: clean

This PR intentionally references rather than closes #24. The CircleCI signature, positive and near-miss fixtures, and its changelog entry remain a separate follow-up after this slug is merged.