### PR TITLE
Add CircleCI detection signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ always bump at least minor; breaking schema changes bump major.
 ## [Unreleased]
 
 ### Added
+- Add Tier 2 CircleCI detection (`infra/circleci`) for `.circleci/config.yml`, with positive and near-miss fixtures (#24).
 - Add `infra/circleci` to the closed skill taxonomy (#24).
 - Document the CLI exit-code contract for scripting and CI (`docs/exit-codes.md`, #29).
 - `redential --version` (and `-V`) prints the CLI version. Program

--- a/signatures/infra/circleci.json
+++ b/signatures/infra/circleci.json
@@ -1,0 +1,16 @@
+{
+  "slug": "infra/circleci",
+  "importPatterns": [],
+  "apiPatterns": [],
+  "configFilePatterns": [
+    "(^|/)\\.circleci/config\\.yml$"
+  ],
+  "fixtures": {
+    "positive": [
+      { "path": ".circleci/config.yml", "diff": "version: 2.1\njobs:\n  test:\n    docker:\n      - image: cimg/node:22.0\n    steps:\n      - checkout\n      - run: npm test" }
+    ],
+    "negative": [
+      { "path": "README.md", "diff": "CircleCI looks for its configuration at .circleci/config.yml." }
+    ]
+  }
+}


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

Adds the Tier 2 CircleCI signature promised in #24 after the taxonomy prerequisite merged in #59. Detection is limited to the canonical `.circleci/config.yml` path; a README mention of that path is retained as a genuine near-miss so documentation alone cannot produce a match.

This makes CircleCI usage locally verifiable without changing the credential schema, data boundary, dependencies, or public API.

## Checklist

- [ ] Tests pass locally (`npm test`)
- [x] `npm run typecheck` passes

### If this adds or changes a detection signature

- [x] Includes at least one positive fixture and one negative fixture
      (the negative fixture is a genuine near-miss, not unrelated text)
- [x] The slug used already exists in `taxonomy.json` - added separately in #59

### If this touches WHAT data leaves the machine, or WHERE it's sent

- [ ] Links the prior "Data boundary change" discussion issue (not applicable)
- [ ] Schema version bumped, with `docs/schema.md` updated (not applicable)
- [ ] Adds/updates a test in `test/privacy/` (not applicable)

### If this adds a new runtime dependency

Not applicable; no dependencies were added.

### Docs and changelog

- [x] `CHANGELOG.md` entry added under `[Unreleased]`
- [ ] Relevant doc in `docs/` added or updated (not applicable; the issue requests signature data only)

## Validation

- `npx vitest run test/skill-detect.test.ts test/privacy/skill-detection-taxonomy.test.ts` - 91 passed
- `npm run typecheck` - passed
- `npm run build` - passed
- Signature JSON parse and `git diff --check` - passed
- Privacy sweeps - no network/API code, source slug, dependency, or postinstall changes
- `npm test` - did not complete within 15 minutes on Windows; the Vitest worker pool remained active without producing a result, so the local-test checkbox remains intentionally open. The full seven-job repository CI matrix passed on Ubuntu, macOS, and Windows

## Additional context

Follow-up to #24 and #59. The merged taxonomy entry is the only prerequisite; this PR does not close the already-closed issue.

