### PR TITLE
fix(merkle): domain-separate leaves/nodes and stop odd-node collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ always bump at least minor; breaking schema changes bump major.
 
 ## [Unreleased]
 
+### Added
+- **RFC 6962 Merkle Tree Hash for `integrity.merkle_root`, with a new
+  `integrity.algorithm` enum value — bundle schema `1.2.0` → `1.3.0`
+  (minor, additive).** `algorithm` widens from the single-value `const
+  "sha256"` to `enum: ["sha256", "rfc6962-sha256"]`. Nothing new travels;
+  it is the same field, naming which Merkle construction produced
+  `merkle_root`. The new construction (leaf prefix `0x00`, node prefix
+  `0x01`, power-of-two split) fixes two weaknesses of the old plain
+  pairwise-SHA-256 root: an internal node could in principle be replayed
+  as a leaf without domain separation, and duplicating a lone node on an
+  odd level meant an odd-sized commit list and that list with its last
+  sha duplicated hashed to the same root (the CVE-2012-2459 class of
+  bug). Old bundles stay fully valid under the `"sha256"` label — the CLI
+  never rewrites them — and new bundles emit `"rfc6962-sha256"`; anything
+  that re-verifies `merkle_root` must branch on `algorithm` rather than
+  assume one construction. Merkle fix by PR #61; schema change discussed
+  and agreed in #62. Field docs:
+  [docs/schema.md](docs/schema.md#algorithm-since-schema-130-enum).
+
 ## [0.8.1] - 2026-08-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ reviewed before any upload:
 
 ```
 {
-  "schema_version": "1.2.0",
+  "schema_version": "1.3.0",
   "runner": "local",
   "tool_version": "0.5.0",
   "created_at": "2026-07-09T14:32:01.000Z",
@@ -147,7 +147,7 @@ reviewed before any upload:
   "categories": [ { "name": "backend", "commit_count": 902, "churn_share": 0.51 }, { "name": "testing", "commit_count": 340, "churn_share": 0.18 } ],
   "detected_skills": [ { "slug": "payments/stripe", "commit_count": 12, "first_seen": "2024-09-01T10:00:00Z", "last_seen": "2025-11-20T18:30:00Z" }, { "slug": "payments/payment-webhook-flow", "commit_count": 4, "first_seen": "2024-09-03T08:00:00Z", "last_seen": "2024-09-03T08:00:00Z", "evidence": "structural", "confidence": "direct" } ],
   "ownership": { "user_commit_ratio": 0.78 },
-  "integrity": { "merkle_root": "7be2…", "algorithm": "sha256", "date_forensics": { "author_span_days": 767, "committer_span_days": 763, "mismatch_ratio": 0.06, "committer_burst_ratio": 0.02 } },
+  "integrity": { "merkle_root": "7be2…", "algorithm": "rfc6962-sha256", "date_forensics": { "author_span_days": 767, "committer_span_days": 763, "mismatch_ratio": 0.06, "committer_burst_ratio": 0.02 } },
   "attestation": { "authorized_confirmation": true, "confirmed_at": "2026-07-09T14:32:01.000Z" }
 }
 ```

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -9,7 +9,7 @@ false` everywhere — unknown fields are invalid by design).
 
 | Field | What | Why |
 |---|---|---|
-| `schema_version` | `"1.2.0"` | The schema is the trust contract; the version pins it |
+| `schema_version` | `"1.3.0"` | The schema is the trust contract; the version pins it |
 | `runner` | `local` \| `ci` | Local scans are user-controlled (weakest tier). CI scans (future) run in employer infrastructure and can carry an OIDC anchor |
 | `tool_version` | CLI version | Reproducibility of the analysis |
 | `created_at` | Scan timestamp | Freshness |
@@ -27,6 +27,26 @@ validator pinned to the literal 1.1.0 schema: `schema_version` is a JSON
 Schema `const`, so that mismatch is rejected on the version string alone,
 by design. Full rationale and the exact field contract:
 [docs/schema-change-h7.md](schema-change-h7.md).
+
+### Version note (1.2.0 → 1.3.0)
+
+`1.3.0` widens `integrity.algorithm` from the single-value `const "sha256"`
+to an `enum: ["sha256", "rfc6962-sha256"]`. Nothing new travels: it is
+the same field, describing the same `merkle_root`, just naming which
+Merkle construction produced it. Discussed and agreed in #62, riding
+#61's fix to two weaknesses of the old plain-pairwise-SHA-256 root (see
+[`integrity`](#integrity) below for what those weaknesses were and how
+RFC 6962 closes them). A bundle emitted before this change (`algorithm:
+"sha256"`) stays fully valid — the CLI never rewrites old bundles, and
+a `1.3.0`-pinned validator still accepts the old label because it is
+still a member of the enum. New bundles emit `algorithm:
+"rfc6962-sha256"`. The one thing this bump changes for consumers:
+anything that re-verifies `merkle_root` must branch on `algorithm`
+instead of assuming one construction — the two labels are not
+interchangeable, only the newer one is RFC 6962. As with the 1.2.0 bump,
+what does NOT carry over is validating a `1.3.0` bundle against a
+validator pinned to the literal `1.2.0` schema: `schema_version` is a
+JSON Schema `const`, rejected on the version string alone, by design.
 
 ## `repo`
 
@@ -219,6 +239,40 @@ above), same as `identity.other_contributors_count`.
 `merkle_root` over the user's commit shas (sha256). Enables future
 re-verification ("does today's repo state still contain the commits you
 attested last year?") without revealing a single sha.
+
+### `algorithm` (since schema 1.3.0, enum)
+
+Names the Merkle construction `merkle_root` was built with:
+
+- `"sha256"` — every bundle from before this change. Plain pairwise
+  SHA-256, with a lone node on an odd level carried up by hashing it
+  against a duplicate of itself.
+- `"rfc6962-sha256"` — the RFC 6962 (Certificate Transparency) Merkle
+  Tree Hash: leaves are `SHA256(0x00 || leaf)`, internal nodes are
+  `SHA256(0x01 || left || right)`, and the tree always splits at the
+  largest power of two, so a lone node is carried up unhashed rather
+  than duplicated.
+
+The switch (#61, discussed in #62) closes two weaknesses the old
+construction had: without a leaf/node domain-separation prefix, an
+internal node's hash could in principle be replayed as if it were a
+leaf; and duplicating the lone node on an odd level meant an odd-sized
+commit list and that same list with its last commit sha duplicated
+produced the *same* root (the CVE-2012-2459 class of bug). Neither
+weakness let any new data leave the machine — both constructions only
+ever hash the user's own commit shas locally — but a root a verifier
+can trust to represent one and only one commit set needs both
+properties.
+
+Old bundles are not rewritten or invalidated: `"sha256"` stays a valid
+enum member forever, so anything submitted before this change keeps
+verifying under the construction it actually used. The CLI itself only
+ever emits `"rfc6962-sha256"` going forward. Any code that
+re-verifies `merkle_root` against a stored bundle must read
+`algorithm` first and use the matching construction — the two hash the
+same input differently, so treating an old bundle as if it were
+`"rfc6962-sha256"` (or vice versa) produces a mismatched root, not an
+error.
 
 ### `date_forensics` (measurement contract)
 

--- a/schema/bundle.v1.json
+++ b/schema/bundle.v1.json
@@ -11,7 +11,7 @@
     "categories", "detected_skills", "ownership", "integrity", "attestation"
   ],
   "properties": {
-    "schema_version": { "const": "1.2.0" },
+    "schema_version": { "const": "1.3.0" },
     "runner": { "enum": ["local", "ci"] },
     "tool_version": { "type": "string" },
     "created_at": { "type": "string", "format": "date-time" },
@@ -159,7 +159,10 @@
           "type": "string",
           "description": "Merkle root over the user's commit shas. Enables future re-verification and consistency checks without revealing the shas."
         },
-        "algorithm": { "const": "sha256" },
+        "algorithm": {
+          "enum": ["sha256", "rfc6962-sha256"],
+          "description": "Merkle construction used for merkle_root. \"sha256\" (every bundle before schema 1.3.0, and still valid) is plain pairwise SHA-256 with a duplicated node on odd levels. \"rfc6962-sha256\" is the RFC 6962 Merkle Tree Hash (leaf prefix 0x00, node prefix 0x01, power-of-two split), which fixes two weaknesses of the old construction: an internal node can never be replayed as a leaf, and odd-sized commit lists no longer collide with their last element duplicated (CVE-2012-2459-style). No new data leaves the machine either way; only the label changes. Verifiers must branch on this field, not assume one construction. See docs/schema.md."
+        },
         "date_forensics": {
           "type": "object",
           "additionalProperties": false,

--- a/src/merkle.ts
+++ b/src/merkle.ts
@@ -1,21 +1,42 @@
 import { createHash } from "node:crypto";
 
-function sha256hex(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
+// Domain-separation prefixes (RFC 6962 / Certificate Transparency): leaves and
+// internal nodes are hashed under different one-byte tags, so an internal node
+// can never be presented as a leaf.
+const LEAF_PREFIX = Buffer.from("00", "hex"); // 0x00
+const NODE_PREFIX = Buffer.from("01", "hex"); // 0x01
+
+function sha256hex(...parts: Array<Buffer | string>): string {
+  const h = createHash("sha256");
+  for (const p of parts) h.update(p);
+  return h.digest("hex");
 }
 
-/** Plain pairwise-sha256 Merkle root over the user's commit shas. */
+/**
+ * RFC 6962 Merkle Tree Hash over the user's commit shas.
+ *
+ * Leaves are `SHA256(0x00 || leaf)` and internal nodes `SHA256(0x01 || left ||
+ * right)` over the raw child digests. Two properties this buys over a plain
+ * pairwise-sha256 root:
+ *
+ *  - Domain separation: the leaf/node prefixes make an internal node
+ *    unforgeable as a leaf (second-preimage resistance).
+ *  - Non-malleable odd levels: the tree splits at the largest power of two, so
+ *    a lone node is carried up, never hashed against a duplicate of itself. The
+ *    old `right = left` duplication made `[A, B, C]` and `[A, B, C, C]` hash to
+ *    the same root; they no longer collide.
+ */
 export function merkleRoot(leaves: string[]): string {
-  let level = leaves.map(sha256hex);
-  if (level.length === 0) return sha256hex("");
-  while (level.length > 1) {
-    const next: string[] = [];
-    for (let i = 0; i < level.length; i += 2) {
-      const left = level[i];
-      const right = i + 1 < level.length ? level[i + 1] : left;
-      next.push(sha256hex(left + right));
-    }
-    level = next;
-  }
-  return level[0];
+  if (leaves.length === 0) return sha256hex(""); // empty tree
+  return mth(leaves);
+}
+
+// Merkle Tree Hash of a non-empty leaf list, returned as hex.
+function mth(leaves: string[]): string {
+  if (leaves.length === 1) return sha256hex(LEAF_PREFIX, leaves[0]);
+  let k = 1;
+  while (k * 2 < leaves.length) k *= 2; // largest power of two strictly < n
+  const left = Buffer.from(mth(leaves.slice(0, k)), "hex");
+  const right = Buffer.from(mth(leaves.slice(k)), "hex");
+  return sha256hex(NODE_PREFIX, left, right);
 }

--- a/src/node-shims.d.ts
+++ b/src/node-shims.d.ts
@@ -27,6 +27,9 @@ declare class Buffer {
   readonly length: number;
   static alloc(size: number): Buffer;
   static concat(list: Buffer[]): Buffer;
+  // `from(string, "hex")` builds the raw bytes merkle.ts needs: the 0x00/0x01
+  // RFC 6962 domain-separation prefixes and the raw child digests it hashes.
+  static from(data: string, encoding?: string): Buffer;
   indexOf(value: string): number;
   slice(start?: number, end?: number): Buffer;
   toString(encoding?: string): string;
@@ -82,7 +85,9 @@ declare module "node:os" {
 
 declare module "node:crypto" {
   export interface Hash {
-    update(data: string): Hash;
+    // Accepts Buffer as well as string so merkle.ts can feed raw byte
+    // prefixes and digests through the hash, not just UTF-8 strings.
+    update(data: string | Buffer): Hash;
     digest(encoding: "hex"): string;
   }
   export function createHash(algorithm: string): Hash;

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -187,7 +187,7 @@ export async function runScan(opts: ScanOptions): Promise<Bundle> {
   const dateForensics = computeDateForensics(userCommits);
 
   const bundle: Bundle = {
-    schema_version: "1.2.0",
+    schema_version: "1.3.0",
     runner: "local",
     tool_version: opts.toolVersion,
     created_at: now.toISOString(),
@@ -211,7 +211,7 @@ export async function runScan(opts: ScanOptions): Promise<Bundle> {
     ownership: { user_commit_ratio: userCommits.length / allCommits.length },
     integrity: {
       merkle_root: merkleRoot(userCommits.map((c) => c.sha)),
-      algorithm: "sha256",
+      algorithm: "rfc6962-sha256",
       date_forensics: dateForensics,
     },
     attestation: { authorized_confirmation: true, confirmed_at: now.toISOString() },

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,7 +80,7 @@ export interface DateForensicsInfo {
 
 export interface IntegrityInfo {
   merkle_root: string;
-  algorithm: "sha256";
+  algorithm: "sha256" | "rfc6962-sha256";
   date_forensics: DateForensicsInfo;
 }
 
@@ -90,7 +90,7 @@ export interface AttestationInfo {
 }
 
 export interface Bundle {
-  schema_version: "1.2.0";
+  schema_version: "1.3.0";
   runner: "local" | "ci";
   tool_version: string;
   created_at: string;

--- a/test/merkle.test.ts
+++ b/test/merkle.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { merkleRoot } from "../src/merkle.js";
+
+describe("merkleRoot", () => {
+  it("is deterministic and order-sensitive", () => {
+    expect(merkleRoot(["a", "b", "c"])).toBe(merkleRoot(["a", "b", "c"]));
+    expect(merkleRoot(["a", "b", "c"])).not.toBe(merkleRoot(["b", "a", "c"]));
+  });
+
+  it("does not collide an odd list with its last element duplicated (CVE-2012-2459)", () => {
+    // The old odd-node handling duplicated the lone node (`right = left`), so
+    // these two distinct commit sets produced the same root. They must differ.
+    expect(merkleRoot(["a", "b", "c"])).not.toBe(merkleRoot(["a", "b", "c", "c"]));
+    expect(merkleRoot(["a"])).not.toBe(merkleRoot(["a", "a"]));
+  });
+
+  it("keeps distinct leaf sets and tree shapes distinct", () => {
+    expect(merkleRoot(["x"])).not.toBe(merkleRoot(["x", "y"]));
+    expect(merkleRoot(["a", "b", "c", "d"])).not.toBe(merkleRoot(["a", "b", "c"]));
+  });
+
+  it("returns a well-formed sha256 hex root for empty and single-leaf trees", () => {
+    expect(merkleRoot([])).toMatch(/^[0-9a-f]{64}$/);
+    expect(merkleRoot(["only"])).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/test/privacy/public-remote-guardrail.test.ts
+++ b/test/privacy/public-remote-guardrail.test.ts
@@ -102,10 +102,10 @@ describe("scan continues after a known-public-host warning (never blocks)", () =
     const bundleLine = logs.find((line) => line.trim().startsWith("{"));
     expect(bundleLine).toBeDefined();
     const bundle = JSON.parse(bundleLine!);
-    // H7 (docs/schema-change-h7.md): schema_version bumped 1.1.0 -> 1.2.0
-    // (additive fields on detected_skills[] entries; unrelated to this
-    // guardrail's own behavior, which this test otherwise leaves untouched).
-    expect(bundle.schema_version).toBe("1.2.0");
+    // Schema 1.3.0 (docs/schema.md's "Version note (1.2.0 -> 1.3.0)"):
+    // integrity.algorithm widened to an enum for RFC 6962; unrelated to this
+    // guardrail's own behavior, which this test otherwise leaves untouched.
+    expect(bundle.schema_version).toBe("1.3.0");
     expect(bundle.commits.user_total).toBe(1);
   });
 

--- a/test/privacy/structural-signal.test.ts
+++ b/test/privacy/structural-signal.test.ts
@@ -147,8 +147,8 @@ describe("structural signal (H7, docs/schema-change-h7.md)", () => {
     const schema = JSON.parse(readFileSync(schemaUrl, "utf8"));
     const item = schema.properties.detected_skills.items;
 
-    it("schema_version is the const 1.2.0", () => {
-      expect(schema.properties.schema_version.const).toBe("1.2.0");
+    it("schema_version is the const 1.3.0", () => {
+      expect(schema.properties.schema_version.const).toBe("1.3.0");
     });
 
     it("evidence/confidence are NOT in detected_skills[] items' required[] (additive, optional)", () => {
@@ -166,12 +166,13 @@ describe("structural signal (H7, docs/schema-change-h7.md)", () => {
       expect(item.properties.confidence.enum).toEqual(["direct", "inferred"]);
     });
 
-    // The additive-compat property in practice: a 1.2.0 bundle with no
+    // The additive-compat property in practice: a bundle with no
     // structural findings emits entries shaped exactly like a 1.1.0 bundle's
     // entries would have been (no evidence/confidence keys anywhere), while
-    // still declaring schema_version 1.2.0.
-    it("a scan of a repo with no structural pattern emits entries with no new fields, under schema_version 1.2.0", () => {
-      expect(noStructuralBundle.schema_version).toBe("1.2.0");
+    // still declaring the current schema_version (1.3.0 as of the
+    // integrity.algorithm enum change; unrelated to evidence/confidence).
+    it("a scan of a repo with no structural pattern emits entries with no new fields, under the current schema_version", () => {
+      expect(noStructuralBundle.schema_version).toBe("1.3.0");
       for (const entry of noStructuralBundle.detected_skills) {
         expect("evidence" in entry).toBe(false);
         expect("confidence" in entry).toBe(false);


### PR DESCRIPTION
### What
`merkleRoot` (the `merkle_root` in the attested proof) used a plain pairwise sha256 with two classic weaknesses:

- **No domain separation.** Leaves (`sha256(v)`) and internal nodes (`sha256(left + right)`) were hashed identically, so an internal node can be presented as a leaf (second-preimage attack).
- **Odd-node duplication.** A lone node was hashed against a copy of itself (`right = left`), so `[A, B, C]` and `[A, B, C, C]` produced the **same root** (CVE-2012-2459 malleability): distinct commit sets collide.

### Fix
Switch to the RFC 6962 (Certificate Transparency) Merkle Tree Hash: leaves `SHA256(0x00 || leaf)`, internal nodes `SHA256(0x01 || left || right)` over the raw child digests, splitting each level at the largest power of two so a lone node is carried up rather than duplicated.

This **changes root values** (the old ones were forgeable), so it should ride a proof-format version bump.

### Tests
Adds `test/merkle.test.ts`: determinism / order-sensitivity, the `[A, B, C]` vs `[A, B, C, C]` non-collision that the old code failed, shape-distinctness, and well-formed empty / single-leaf roots.
