### PR TITLE
fix: detect manifest dependencies added inside existing blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning: strict [semver](https://semver.org/) — bundle schema changes
 always bump at least minor; breaking schema changes bump major.
 
-## [0.10.1] - 2026-08-07
+## [Unreleased]
 
+### Fixed
+- Improve manifest dependency detection by comparing parent and child
+  snapshots, preventing false positives from dependency version changes.
+
+
+## [0.10.1] - 2026-08-07
 ### Added
 - Add `payments/braintree` to the closed skill taxonomy (#14).
 - Detect Braintree via `braintree`, `braintree-web`, and `braintree-web-drop-in` imports, mapped to `payments/braintree` (#14).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ always bump at least minor; breaking schema changes bump major.
 
 ### Fixed
 - Improve manifest dependency detection by comparing parent and child
-  snapshots, preventing false positives from dependency version changes.
+  revision snapshots instead of relying only on added diff lines. This now
+  correctly detects dependencies added inside existing blocks in
+  `package.json`, `composer.json`, and `Cargo.toml` while ignoring existing
+  dependencies and version-only changes.
+- Add safer manifest parsing behavior by failing closed when a child or parent
+  manifest cannot be parsed, preventing malformed files from causing
+  over-attribution of dependencies.
+- Batch manifest snapshot reads across commits to reduce repeated Git blob
+  lookups during dependency detection.
 
 
 ## [0.10.1] - 2026-08-07
@@ -139,15 +147,6 @@ always bump at least minor; breaking schema changes bump major.
   collapse").
 
 ## [0.8.0] - 2026-08-02
-
-### Fixed
-- Fix manifest dependency detection for existing dependency blocks in
-  `package.json`, `composer.json`, and `Cargo.toml`. Manifest matching now
-  compares parent and child revision snapshots instead of relying only on
-  added diff lines, so dependencies added inside existing blocks are detected
-  correctly while existing dependencies and version-only changes are ignored.
-- Update manifest detection documentation to remove the previous documented
-  miss for dependency additions inside existing sections.
 
 ### Added
 - Add Tier 2 CircleCI detection (`infra/circleci`) for `.circleci/config.yml`, with positive and near-miss fixtures (#24).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ always bump at least minor; breaking schema changes bump major.
 
 
 ## [0.10.1] - 2026-08-07
+
 ### Added
 - Add `payments/braintree` to the closed skill taxonomy (#14).
 - Detect Braintree via `braintree`, `braintree-web`, and `braintree-web-drop-in` imports, mapped to `payments/braintree` (#14).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,15 @@ always bump at least minor; breaking schema changes bump major.
 
 ## [0.8.0] - 2026-08-02
 
+### Fixed
+- Fix manifest dependency detection for existing dependency blocks in
+  `package.json`, `composer.json`, and `Cargo.toml`. Manifest matching now
+  compares parent and child revision snapshots instead of relying only on
+  added diff lines, so dependencies added inside existing blocks are detected
+  correctly while existing dependencies and version-only changes are ignored.
+- Update manifest detection documentation to remove the previous documented
+  miss for dependency additions inside existing sections.
+
 ### Added
 - Add Tier 2 CircleCI detection (`infra/circleci`) for `.circleci/config.yml`, with positive and near-miss fixtures (#24).
 - Add `infra/circleci` to the closed skill taxonomy (#24).

--- a/docs/signatures.md
+++ b/docs/signatures.md
@@ -27,12 +27,18 @@ scope" below), normalizes each to a package name (`stripe/webhooks` →
 stripped, …), and looks it up in `signatures/package-map.json` — a flat
 `{"package-name": "taxonomy-slug"}` map, 600+ entries.
 
-`package.json` dependency detection is intentionally conservative:
-dependency entries are only attributed when the relevant dependency block
-header (`dependencies`, `devDependencies`, or `peerDependencies`) is
-present in the added diff lines. Without that context, a standalone
-`"package": "version"` entry cannot be safely attributed and is treated
-as a documented miss rather than guessed evidence.
+Manifest dependency detection (`package.json`, `composer.json`, and
+`Cargo.toml`) compares the parent and child manifest snapshots 
+rather than relying only on dependency block headers appearing in
+the added diff lines. This allows dependencies added inside an existing
+`dependencies`, `devDependencies`, or `peerDependencies` block to be
+attributed safely because the evidence comes from the actual manifest state
+before and after the commit.
+
+Only dependencies newly present in the child manifest are emitted; unchanged
+dependencies are ignored. This avoids attributing existing dependencies from
+previous commits while still detecting additions where the diff context does
+not include the dependency block header.
 
 Deliberately regex-based, not a real parser per language (a dependency per
 language is a supply-chain surface CLAUDE.md's policy doesn't allow without
@@ -75,10 +81,14 @@ body's `key = ...` lines are read as crate names, and a dotted
 `[dependencies.tokio]` header, whose crate name is the header itself (its
 body is NOT key-scanned — `version`/`features`/... are Cargo.toml keys,
 not crate names, and scanning them would be a real false-positive class).
-Anything else — `[target.'cfg(...)'.dependencies]`, a dependency added
-under an already-existing header not itself re-shown in the diff — is a
-documented miss, same tradeoff class as composer.json's "only reliable
-when the diff has enough context." Crate names with a hyphen
+Anything else — `[target.'cfg(...)'.dependencies]` sections, or dependency
+changes that cannot be safely attributed from the supported manifest shapes —
+is not interpreted as a dependency source by this extractor. Supported
+`Cargo.toml` dependency sections are evaluated by comparing the parent and
+child manifest snapshots, allowing dependencies added inside an existing
+`[dependencies]` section to be detected safely. This removes the previous
+limitation where a dependency could only be detected when the dependency
+section header appeared in the added diff context. Crate names with a hyphen
 (`actix-web`, crates.io convention) are normalized to the underscore form
 Rust identifiers actually use (`actix_web`) at BOTH extraction sites, so a
 Cargo.toml addition and the `use` statement consuming it resolve to the

--- a/src/git.ts
+++ b/src/git.ts
@@ -11,7 +11,7 @@ export interface FileChurn {
 
 export interface RawCommit {
   sha: string;
-  parentSha: string;
+  parentSha: string | undefined;
   email: string;
   authorDate: Date;
   // Distinct from authorDate: the date the commit object was actually
@@ -694,11 +694,11 @@ export function listHeadTreeBlobs(repoPath: string): Promise<HeadTreeEntry[]> {
  * matching getCommitsAddedLines' fail-quiet-to-partial-data behavior — a
  * missing snapshot file is not a privacy problem, only a completeness one.
  */
-export function readBlobContents(repoPath: string, revision: string, paths: string[]): Promise<Map<string, string>> {
-  const result = new Map<string, string>();
-  if (paths.length === 0) return Promise.resolve(result);
+export function readBlobContents(repoPath: string, requests: { revision: string; path: string }[]): Promise<Map<string, Map<string, string>>> {
+  const result = new Map<string, Map<string, string>>();
+  if (requests.length === 0) return Promise.resolve(result);
 
-  debugLog(`git cat-file --batch <${paths.length} paths> (batched content fetch)`);
+  debugLog(`git cat-file --batch <${requests.length} paths> (batched content fetch)`);
 
   return new Promise((resolve) => {
     const child = spawn("git", ["cat-file", "--batch"], {
@@ -707,7 +707,8 @@ export function readBlobContents(repoPath: string, revision: string, paths: stri
     });
 
     let buffer = Buffer.alloc(0);
-    let index = 0; // position in `paths` — cat-file --batch answers strictly in request order
+    let index = 0; // position in `requests` — cat-file --batch answers
+    // strictly in request order.
 
     const tryParse = () => {
       for (;;) {
@@ -728,10 +729,17 @@ export function readBlobContents(repoPath: string, revision: string, paths: stri
         const contentStart = headerEnd + 1;
         const contentEnd = contentStart + size;
         if (buffer.length < contentEnd + 1) return; // content + trailing \n not fully buffered yet
-        const path = paths[index];
-        if (path !== undefined) {
-          result.set(path, buffer.slice(contentStart, contentEnd).toString("utf8"));
+        const content = buffer.slice(contentStart, contentEnd).toString("utf8");
+        const request = requests[index];
+        if (request === undefined) {
+         return;
         }
+        let revisionMap = result.get(request.revision);
+        if (revisionMap === undefined) {
+          revisionMap = new Map<string, string>();
+          result.set(request.revision, revisionMap);
+        }
+        revisionMap.set(request.path, content);
         buffer = buffer.slice(contentEnd + 1);
         index++;
       }
@@ -747,7 +755,7 @@ export function readBlobContents(repoPath: string, revision: string, paths: stri
     child.on("error", () => resolve(result));
     child.on("close", () => resolve(result));
 
-    child.stdin!.write(paths.map((p) => `${revision}:${p}\n`).join(""));
+    child.stdin!.write(requests.map((request) => `${request.revision}:${request.path}\n`).join(""));
     child.stdin!.end();
   });
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -11,6 +11,7 @@ export interface FileChurn {
 
 export interface RawCommit {
   sha: string;
+  parentSha: string;
   email: string;
   authorDate: Date;
   // Distinct from authorDate: the date the commit object was actually
@@ -107,6 +108,7 @@ function parseCommitRecord(record: string): RawCommit {
     signed: signatureStatus === "G",
     churn,
     isMerge: parents.trim().split(/\s+/).filter(Boolean).length > 1,
+    parentSha: parents.trim().split(/\s+/).filter(Boolean)[0],
   };
 }
 
@@ -660,6 +662,18 @@ export function listHeadTreeBlobs(repoPath: string): Promise<HeadTreeEntry[]> {
  * getCommitsAddedLines/skill-detect.ts's DIFF_BATCH_SIZE split, so at most
  * one batch's worth of file content is ever held in memory at once.
  *
+ * Although this helper was originally introduced for HEAD snapshot reads,
+ * it now accepts any git revision. HEAD is simply the current checked-out
+ * revision; callers may also provide historical commit SHAs, such as a
+ * commit being analyzed and its parent commit. This allows callers like
+ * skill detection to compare two repository states:
+ *
+ *   parent revision -> child revision
+ *
+ * instead of relying only on partial diff lines. This is required for
+ * manifest dependency detection, where the full before/after file contents
+ * are needed to identify newly added dependencies safely.
+ *
  * `--batch` was chosen over N calls to `git show HEAD:path` (one process
  * per file — exactly the cost this exists to avoid) or one `git show`
  * given many `HEAD:path` args back to back (which does concatenate blob
@@ -680,7 +694,7 @@ export function listHeadTreeBlobs(repoPath: string): Promise<HeadTreeEntry[]> {
  * matching getCommitsAddedLines' fail-quiet-to-partial-data behavior — a
  * missing snapshot file is not a privacy problem, only a completeness one.
  */
-export function readHeadBlobContents(repoPath: string, paths: string[]): Promise<Map<string, string>> {
+export function readBlobContents(repoPath: string, revision: string, paths: string[]): Promise<Map<string, string>> {
   const result = new Map<string, string>();
   if (paths.length === 0) return Promise.resolve(result);
 
@@ -733,7 +747,7 @@ export function readHeadBlobContents(repoPath: string, paths: string[]): Promise
     child.on("error", () => resolve(result));
     child.on("close", () => resolve(result));
 
-    child.stdin!.write(paths.map((p) => `HEAD:${p}\n`).join(""));
+    child.stdin!.write(paths.map((p) => `${revision}:${p}\n`).join(""));
     child.stdin!.end();
   });
 }

--- a/src/import-detect.ts
+++ b/src/import-detect.ts
@@ -170,6 +170,28 @@ function extractJsImports(text: string): string[] {
   return found;
 }
 
+// Parses a complete package.json manifest and returns the dependency names
+// declared in dependencies, devDependencies, and peerDependencies. Unlike
+// diff-line parsing, this uses JSON.parse so single-line dependency blocks
+// and formatting variations are handled correctly.
+function extractPackageJsonFromManifest(text: string): string[] {
+  try {
+    const parsed = JSON.parse(text) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+    };
+
+    return [
+      ...Object.keys(parsed.dependencies ?? {}),
+      ...Object.keys(parsed.devDependencies ?? {}),
+      ...Object.keys(parsed.peerDependencies ?? {}),
+    ];
+  } catch {
+    return [];
+  }
+}
+
 const PACKAGE_JSON_DEPS_HEADER = /^"(dependencies|devDependencies|peerDependencies)"\s*:\s*\{$/;
 const PACKAGE_JSON_DEP_LINE = /^"([^"]+)"\s*:/;
 // package.json is parsed from added diff lines only. A dependency block
@@ -280,7 +302,7 @@ function extractRuby(text: string, filePath: string): string[] {
   return found;
 }
 
-function extractPhp(text: string, filePath: string): string[] {
+function extractPhp(text: string, filePath: string): string[] | undefined {
   const found: string[] = [];
   if (/composer\.json$/i.test(filePath)) {
     // Structured JSON — no regex needed, and safest possible source: no
@@ -292,6 +314,7 @@ function extractPhp(text: string, filePath: string): string[] {
       // A partial diff (added lines only) is rarely valid standalone JSON —
       // fall through to returning whatever we found (nothing), rather than
       // guessing at a malformed fragment.
+      return [];
     }
     return found;
   }
@@ -536,9 +559,9 @@ function extractSwift(text: string, filePath: string): string[] {
  * effort guess. Detection prefers bounded false negatives over unsafe
  * attribution.
  */
-function parseManifestDependencies(text: string, filePath: string): string[] {
+function parseManifestDependencies(text: string, filePath: string): string[] | undefined {
   if(/package\.json$/i.test(filePath)) {
-    return extractPackageJson(text);
+    return extractPackageJsonFromManifest(text);
   }
   if(/cargo\.toml$/i.test(filePath)) {
     return extractCargoToml(text);
@@ -570,7 +593,7 @@ export function sanitizeForPatternMatching(addedLines: string): string {
  * extension isn't recognized, or for excluded doc files (.md etc.) — never
  * throws.
  */
-export function extractImportedPackages(addedLines: string, filePath: string): string[] {
+export function extractImportedPackages(addedLines: string, filePath: string): string[]{
   const language = languageForPath(filePath);
   if (!language) return [];
   // composer.json (structured JSON) and Cargo.toml/.csproj (each parsed by
@@ -595,7 +618,7 @@ export function extractImportedPackages(addedLines: string, filePath: string): s
     case "ruby":
       return extractRuby(text, filePath);
     case "php":
-      return extractPhp(text, filePath);
+      return extractPhp(text, filePath)?? [];
     case "rust":
       return extractRust(text, filePath);
     case "java":
@@ -632,9 +655,19 @@ export function extractAddedManifestDependencies(
 ): string[] {
 
   const childDeps = parseManifestDependencies(childText, filePath);
-  if (!parentText) {
+  if (childDeps === undefined) {
+    return [];
+  }
+  // Root commit (or newly introduced manifest): attribute every dependency
+  // present in the child snapshot.
+  if (parentText === undefined) {
     return childDeps;
   }
   const parentDeps = parseManifestDependencies(parentText, filePath);
-  return childDeps.filter(dep => !parentDeps.includes(dep));
+  // If the parent manifest can't be parsed, fail closed rather than treating
+  // the child as a newly introduced manifest and over-attributing skills.
+  if (parentDeps === undefined) {
+    return [];
+  }
+  return childDeps.filter((dep) => !parentDeps.includes(dep));
 }

--- a/src/import-detect.ts
+++ b/src/import-detect.ts
@@ -174,7 +174,7 @@ function extractJsImports(text: string): string[] {
 // declared in dependencies, devDependencies, and peerDependencies. Unlike
 // diff-line parsing, this uses JSON.parse so single-line dependency blocks
 // and formatting variations are handled correctly.
-function extractPackageJsonFromManifest(text: string): string[] {
+function extractPackageJsonFromManifest(text: string): string[] | undefined  {
   try {
     const parsed = JSON.parse(text) as {
       dependencies?: Record<string, string>;
@@ -188,7 +188,7 @@ function extractPackageJsonFromManifest(text: string): string[] {
       ...Object.keys(parsed.peerDependencies ?? {}),
     ];
   } catch {
-    return [];
+    return undefined;
   }
 }
 
@@ -314,7 +314,7 @@ function extractPhp(text: string, filePath: string): string[] | undefined {
       // A partial diff (added lines only) is rarely valid standalone JSON —
       // fall through to returning whatever we found (nothing), rather than
       // guessing at a malformed fragment.
-      return [];
+      return undefined;
     }
     return found;
   }
@@ -661,6 +661,10 @@ export function extractAddedManifestDependencies(
   // Root commit (or newly introduced manifest): attribute every dependency
   // present in the child snapshot.
   if (parentText === undefined) {
+    // Missing parent content can mean either a root/new manifest commit or a
+    // failed parent blob read. We cannot distinguish these cases here; treating
+    // it as a new manifest preserves existing fail-quiet behavior but may
+    // over-attribute dependencies in the rare git failure case.
     return childDeps;
   }
   const parentDeps = parseManifestDependencies(parentText, filePath);

--- a/src/import-detect.ts
+++ b/src/import-detect.ts
@@ -521,6 +521,36 @@ function extractSwift(text: string, filePath: string): string[] {
   return isPackageSwiftManifest(filePath) ? extractPackageSwiftDependencies(text) : extractSwiftImport(text);
 }
 
+/**
+ * Extracts dependency names from supported manifest formats.
+ *
+ * This function intentionally dispatches to format-specific extractors rather
+ * than attempting generic manifest parsing. Each ecosystem has different
+ * dependency semantics:
+ *
+ * - package.json: dependencies/devDependencies/peerDependencies
+ * - Cargo.toml: Cargo dependency sections
+ * - composer.json: PHP require block
+ *
+ * Unknown manifest types return an empty list rather than attempting a best
+ * effort guess. Detection prefers bounded false negatives over unsafe
+ * attribution.
+ */
+function parseManifestDependencies(text: string, filePath: string): string[] {
+  if(/package\.json$/i.test(filePath)) {
+    return extractPackageJson(text);
+  }
+  if(/cargo\.toml$/i.test(filePath)) {
+    return extractCargoToml(text);
+  }
+  if(/composer\.json$/i.test(filePath)) {
+    return extractPhp(text,filePath);
+  }
+  
+  return [];
+  
+}
+
 /** Tier 2 import/api pattern matching: block comments + whole comment lines only.
  *  Deliberately does NOT blank template literals or string contents — apiPatterns
  *  key on quoted API shapes and template-literal URLs (e.g. auth/oauth-oidc). */
@@ -576,4 +606,35 @@ export function extractImportedPackages(addedLines: string, filePath: string): s
     case "swift":
       return extractSwift(text, filePath);
   }
+}
+
+/**
+ * Returns dependencies that were newly introduced by comparing a manifest's
+ * parent and child snapshots.
+ *
+ * Manifest files cannot reliably be analyzed from added diff lines alone:
+ * dependency entries often appear inside an already-existing dependency block
+ * whose header is not part of the diff context. Comparing complete manifests
+ * avoids attributing unchanged dependencies as newly added evidence.
+ *
+ * Version-only changes are intentionally ignored because the dependency key
+ * already existed in the parent manifest. A newly created manifest has no
+ * parent snapshot, so all detected dependencies are treated as additions.
+ *
+ * The comparison is performed locally from git blob contents; no network or
+ * external resolution is involved. The returned values are package names that
+ * are later resolved against the closed signature package map.
+ */
+export function extractAddedManifestDependencies(
+  parentText: string | undefined,
+  childText: string,
+  filePath: string
+): string[] {
+
+  const childDeps = parseManifestDependencies(childText, filePath);
+  if (!parentText) {
+    return childDeps;
+  }
+  const parentDeps = parseManifestDependencies(parentText, filePath);
+  return childDeps.filter(dep => !parentDeps.includes(dep));
 }

--- a/src/import-detect.ts
+++ b/src/import-detect.ts
@@ -569,9 +569,9 @@ function parseManifestDependencies(text: string, filePath: string): string[] | u
   if(/composer\.json$/i.test(filePath)) {
     return extractPhp(text,filePath);
   }
-  
+
   return [];
-  
+
 }
 
 /** Tier 2 import/api pattern matching: block comments + whole comment lines only.

--- a/src/proof-graph/snapshot.ts
+++ b/src/proof-graph/snapshot.ts
@@ -165,17 +165,23 @@ export async function readHeadSnapshot(repoPath: string, opts: SnapshotOptions =
   const files: SnapshotFile[] = [];
   for (let i = 0; i < selectedPaths.length; i += CONTENT_BATCH_SIZE) {
     const batch = selectedPaths.slice(i, i + CONTENT_BATCH_SIZE);
-    const contentByPath = await readBlobContents(repoPath, "HEAD", batch);
+    // Fetch each batch in a single git invocation rather than spawning one
+    // process per file.
+    const requests = batch.map((path) => ({
+    revision: "HEAD",
+    path,
+    }));
+    const contentByRevision = await readBlobContents(repoPath, requests);
+    const headContent = contentByRevision.get("HEAD");
+
+    if (!headContent) continue;
+
     for (const path of batch) {
-      const content = contentByPath.get(path);
-      // This caller intentionally reads from HEAD (the current repository
-      // snapshot). readBlobContents also supports arbitrary revisions, but this
-      // flow only needs the checked-out HEAD state.
-      //
-      // Missing only if readBlobContents' fail-quiet path was hit
-      // (e.g. a concurrent history rewrite mid-read) — skip rather than
-      // include a file with no content.
-      if (content !== undefined) files.push({ path, content });
+      const content = headContent.get(path);
+
+      if (content !== undefined) {
+        files.push({ path, content });
+      }
     }
     opts.onProgress?.(Math.min(i + CONTENT_BATCH_SIZE, selectedPaths.length), selectedPaths.length);
   }

--- a/src/proof-graph/snapshot.ts
+++ b/src/proof-graph/snapshot.ts
@@ -1,4 +1,4 @@
-import { listHeadTreeBlobs, readHeadBlobContents } from "../git.js";
+import { listHeadTreeBlobs, readBlobContents } from "../git.js";
 import { isExcludedPath } from "../churn-exclusions.js";
 import { debugLog } from "../debug.js";
 
@@ -31,11 +31,18 @@ const DEFAULT_MAX_FILES = 5000;
 
 // Content for this many surviving paths is fetched (and held) at once, via
 // a single batched `git cat-file --batch` process (git.ts's
-// readHeadBlobContents), instead of one process per file — same
+// readBlobContents), instead of one process per file — same
 // "subprocess spawn count is the dominant cost at scale" rationale as
-// skill-detect.ts's DIFF_BATCH_SIZE, and it bounds how much file content is
-// ever in memory simultaneously to one batch's worth, not the whole
-// snapshot's.
+// skill-detect.ts's DIFF_BATCH_SIZE.
+//
+// `readBlobContents` reads files from a requested git revision rather than
+// only from HEAD. HEAD represents the currently checked-out snapshot, but
+// callers may need historical snapshots as well (for example, a commit and
+// its parent when comparing manifest changes). The batching behavior remains
+// identical regardless of which revision is being read.
+//
+// This bounds how much file content is ever in memory simultaneously to one
+// batch's worth, not the whole repository snapshot.
 //
 // Raised from 200 to 1000 (measured): at 2000 files, 200 meant 10 batches —
 // each batch pays a fixed `git cat-file --batch` process-spawn cost on top
@@ -130,7 +137,7 @@ export async function readHeadSnapshot(repoPath: string, opts: SnapshotOptions =
     if (isExcludedPath(entry.path)) continue;
     if (isSnapshotLocalExcludedPath(entry.path)) continue;
     if (entry.size > maxFileBytes) {
-      // The path itself is never logged (see readHeadBlobContents' doc
+      // The path itself is never logged (see readBlobContents' doc
       // comment on src/debug.ts's paste-safety invariant) — only the
       // reason and the size that triggered it.
       debugLog(`snapshot: excluded a file over the size cap (${entry.size} bytes > ${maxFileBytes} bytes)`);
@@ -158,10 +165,14 @@ export async function readHeadSnapshot(repoPath: string, opts: SnapshotOptions =
   const files: SnapshotFile[] = [];
   for (let i = 0; i < selectedPaths.length; i += CONTENT_BATCH_SIZE) {
     const batch = selectedPaths.slice(i, i + CONTENT_BATCH_SIZE);
-    const contentByPath = await readHeadBlobContents(repoPath, batch);
+    const contentByPath = await readBlobContents(repoPath, "HEAD", batch);
     for (const path of batch) {
       const content = contentByPath.get(path);
-      // Missing only if readHeadBlobContents' fail-quiet path was hit
+      // This caller intentionally reads from HEAD (the current repository
+      // snapshot). readBlobContents also supports arbitrary revisions, but this
+      // flow only needs the checked-out HEAD state.
+      //
+      // Missing only if readBlobContents' fail-quiet path was hit
       // (e.g. a concurrent history rewrite mid-read) — skip rather than
       // include a file with no content.
       if (content !== undefined) files.push({ path, content });

--- a/src/skill-detect.ts
+++ b/src/skill-detect.ts
@@ -1,13 +1,13 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join } from "node:path";
-import { getCommitsAddedLines, type RawCommit } from "./git.js";
+import { getCommitsAddedLines, type RawCommit, readBlobContents } from "./git.js";
 import { isExcludedPath, heuristicallyGeneratedPaths } from "./churn-exclusions.js";
 import { extractImportedPackages, sanitizeForPatternMatching, extractAddedManifestDependencies } from "./import-detect.js";
 import { ScanError } from "./errors.js";
 import { debugLog } from "./debug.js";
 import type { DetectedSkill } from "./types.js";
-import { readBlobContents } from "./git.js";
+
 
 export interface FixtureCase {
   path: string;

--- a/src/skill-detect.ts
+++ b/src/skill-detect.ts
@@ -3,10 +3,12 @@ import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 import { getCommitsAddedLines, type RawCommit } from "./git.js";
 import { isExcludedPath, heuristicallyGeneratedPaths } from "./churn-exclusions.js";
-import { extractImportedPackages, sanitizeForPatternMatching } from "./import-detect.js";
+import { extractImportedPackages, sanitizeForPatternMatching, extractAddedManifestDependencies } from "./import-detect.js";
 import { ScanError } from "./errors.js";
 import { debugLog } from "./debug.js";
 import type { DetectedSkill } from "./types.js";
+import { readBlobContents } from "./git.js";
+import { execFileSync } from "node:child_process";
 
 export interface FixtureCase {
   path: string;
@@ -29,6 +31,14 @@ interface CompiledSignature {
   importRegexes: RegExp[];
   apiRegexes: RegExp[];
   configFileRegexes: RegExp[];
+}
+
+function needsFullFileContent(filePath: string): boolean {
+  return (
+    /package\.json$/i.test(filePath) ||
+    /composer\.json$/i.test(filePath) ||
+    /cargo\.toml$/i.test(filePath)
+  );
 }
 
 // Default locations ship alongside dist/ in the published package (see
@@ -271,11 +281,47 @@ export async function detectSkills(
       );
       if (files.length === 0) continue;
 
+      const manifestPaths = files
+        .filter((f) => needsFullFileContent(f.path))
+        .map((f) => f.path);
+
+      // Manifest detection compares the complete file state before and after
+      // the commit. This avoids relying on partial diff lines where dependency
+      // block headers may not be included.
+      const childContentByPath =
+        manifestPaths.length > 0
+          ? await readBlobContents(repoPath, commit.sha, manifestPaths)
+          : new Map<string, string>();
+      
+      const parentContentByPath =
+        manifestPaths.length > 0
+          ? await readBlobContents(repoPath, commit.parentSha, manifestPaths)
+          : new Map<string, string>();    
+
       for (const file of files) {
-        // Tier 1: generic import detection against the flat package map.
-        for (const pkg of extractImportedPackages(file.addedLines, file.path)) {
-          const slug = packageMap.get(pkg);
-          if (slug) recordMatch(slug, commit);
+        const addedLines = file.addedLines;
+         if (needsFullFileContent(file.path)) {
+          // Compare parent and child manifests to find newly introduced
+          // dependencies.
+          const parentText = parentContentByPath.get(file.path);
+          const childText = childContentByPath.get(file.path);
+          if (childText == undefined) {
+            continue;
+          }
+          for (const pkg of extractAddedManifestDependencies(
+            parentText,
+            childText,
+            file.path
+          )) {
+            const slug = packageMap.get(pkg);
+            if (slug) recordMatch(slug, commit);
+          }
+        } else {
+           // Tier 1: generic import detection against the flat package map.
+          for (const pkg of extractImportedPackages(addedLines, file.path)) {
+            const slug = packageMap.get(pkg);
+            if (slug) recordMatch(slug, commit);
+          }
         }
       }
       // Tier 2: config-file/API-usage signatures.

--- a/src/skill-detect.ts
+++ b/src/skill-detect.ts
@@ -8,7 +8,6 @@ import { ScanError } from "./errors.js";
 import { debugLog } from "./debug.js";
 import type { DetectedSkill } from "./types.js";
 import { readBlobContents } from "./git.js";
-import { execFileSync } from "node:child_process";
 
 export interface FixtureCase {
   path: string;
@@ -275,37 +274,51 @@ export async function detectSkills(
       batch.map((c) => c.sha)
     );
 
+    const childRequests: { revision: string; path: string }[] = [];
+    const parentRequests: { revision: string; path: string }[] = [];
     for (const commit of batch) {
       const files = (addedLinesBySha.get(commit.sha) ?? []).filter(
         (f) => !isExcludedPath(f.path) && !generatedPaths.has(f.path)
       );
       if (files.length === 0) continue;
 
+      // Only manifest files require full-file snapshots. Source files continue to
+      // use added diff lines for import-based detection.
       const manifestPaths = files
         .filter((f) => needsFullFileContent(f.path))
         .map((f) => f.path);
 
-      // Manifest detection compares the complete file state before and after
-      // the commit. This avoids relying on partial diff lines where dependency
-      // block headers may not be included.
-      const childContentByPath =
-        manifestPaths.length > 0
-          ? await readBlobContents(repoPath, commit.sha, manifestPaths)
-          : new Map<string, string>();
-      
-      const parentContentByPath =
-        manifestPaths.length > 0
-          ? await readBlobContents(repoPath, commit.parentSha, manifestPaths)
-          : new Map<string, string>();    
+      for(const manifest of manifestPaths) {
+       // Queue both child and parent revisions. Root commits have no parent, so only
+       // the child snapshot is requested.
+       childRequests.push({ revision: commit.sha, path: manifest });
+       if (commit.parentSha !== undefined) {
+          parentRequests.push({ revision: commit.parentSha, path: manifest });
+        }
+      }
+    }
+    // Fetch all requested blobs in two batched git invocations rather than one
+    // process per file.
+    const childContentByRevision = await readBlobContents(repoPath, childRequests);
+    const parentContentByRevision = await readBlobContents(repoPath, parentRequests);
+
+    for (const commit of batch) {
+      const files = (addedLinesBySha.get(commit.sha) ?? []).filter(
+        (f) => !isExcludedPath(f.path) && !generatedPaths.has(f.path)
+      );
+      if (files.length === 0) continue;
 
       for (const file of files) {
         const addedLines = file.addedLines;
          if (needsFullFileContent(file.path)) {
-          // Compare parent and child manifests to find newly introduced
-          // dependencies.
-          const parentText = parentContentByPath.get(file.path);
-          const childText = childContentByPath.get(file.path);
-          if (childText == undefined) {
+          // Manifest files are compared as complete snapshots. This detects newly
+          // added dependencies while ignoring version bumps and avoiding diff-format
+          // edge cases.
+          const parentText =  commit.parentSha !== undefined
+          ? parentContentByRevision.get(commit.parentSha)?.get(file.path)
+          : undefined;
+          const childText = childContentByRevision.get(commit.sha)?.get(file.path);
+          if (childText === undefined) {
             continue;
           }
           for (const pkg of extractAddedManifestDependencies(

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -281,6 +281,7 @@ describe("runScan", () => {
       },
     });
 
+
     const bundle = await runScan({
       repoPath: dir,
       authors: ["ivy@example.com"],
@@ -297,6 +298,171 @@ describe("runScan", () => {
         last_seen: bundle.commits.first_at,
       },
     ]);
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  });
+  
+  it("detects newly added package.json dependencies by comparing parent and child manifests", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "add package.json",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      files: {
+        "package.json": [
+          "{",
+          '  "dependencies": {}',
+          "}",
+        ].join("\n"),
+      },
+    });
+
+    commit(dir, {
+      message: "add stripe dependency",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      files: {
+        "package.json": [
+          "{",
+          '  "dependencies": {',
+          '    "stripe": "^16.0.0"',
+          "  }",
+          "}",
+        ].join("\n"),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([
+      {
+        slug: "payments/stripe",
+        commit_count: 1,
+        first_seen: bundle.commits.first_at,
+        last_seen: bundle.commits.first_at,
+      },
+    ]);
+
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  });
+
+
+  it("detects newly added Cargo.toml dependencies by comparing parent and child manifests", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "add Cargo.toml",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      files: {
+        "Cargo.toml": [
+          "[package]",
+          'name = "demo"',
+          'version = "0.1.0"',
+          "",
+          "[dependencies]",
+        ].join("\n"),
+      },
+    });
+
+    commit(dir, {
+      message: "add tokio dependency",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      files: {
+        "Cargo.toml": [
+          "[package]",
+          'name = "demo"',
+          'version = "0.1.0"',
+          "",
+          "[dependencies]",
+          'tokio = "1.0"',
+        ].join("\n"),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([
+      {
+        slug: "backend/tokio",
+        commit_count: 1,
+        first_seen: bundle.commits.first_at,
+        last_seen: bundle.commits.first_at,
+      },
+    ]);
+
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  });
+
+
+  it("detects newly added composer.json dependencies by comparing parent and child manifests", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "add composer.json",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      files: {
+        "composer.json": JSON.stringify(
+          {
+            require: {},
+          },
+          null,
+          2
+        ),
+      },
+    });
+
+    commit(dir, {
+      message: "add laravel dependency",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      files: {
+        "composer.json": JSON.stringify(
+          {
+            require: {
+              "laravel/framework": "^11.0",
+            },
+          },
+          null,
+          2
+        ),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([
+      {
+        slug: "backend/laravel",
+        commit_count: 1,
+        first_seen: bundle.commits.first_at,
+        last_seen: bundle.commits.first_at,
+      },
+    ]);
+
     expect(validateAgainstSchema(schema, bundle)).toEqual([]);
   });
 

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -458,8 +458,8 @@ describe("runScan", () => {
       {
         slug: "backend/laravel",
         commit_count: 1,
-        first_seen: bundle.commits.first_at,
-        last_seen: bundle.commits.first_at,
+        first_seen: bundle.commits.last_at,
+        last_seen: bundle.commits.last_at,
       },
     ]);
 

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -309,6 +309,7 @@ describe("runScan", () => {
       message: "add package.json",
       authorName: "Ivy",
       authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z",
       files: {
         "package.json": [
           "{",
@@ -322,6 +323,7 @@ describe("runScan", () => {
       message: "add stripe dependency",
       authorName: "Ivy",
       authorEmail: "ivy@example.com",
+      authorDate: "2026-01-02T10:00:00Z",
       files: {
         "package.json": [
           "{",
@@ -353,6 +355,170 @@ describe("runScan", () => {
     expect(validateAgainstSchema(schema, bundle)).toEqual([]);
   });
 
+  it("detects newly added package.json dependency blocks", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "add empty package.json",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z",
+      files: {
+        "package.json": JSON.stringify({}, null, 2),
+      },
+    });
+
+    commit(dir, {
+      message: "add stripe dependency block",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-02T10:00:00Z",
+      files: {
+        "package.json": JSON.stringify(
+          {
+            dependencies: {
+              stripe: "^16.0.0",
+            },
+          },
+          null,
+          2
+        ),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([
+      {
+        slug: "payments/stripe",
+        commit_count: 1,
+        first_seen: bundle.commits.last_at,
+        last_seen: bundle.commits.last_at,
+      },
+    ]);
+
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  });
+
+  it("does not detect package.json dependency version bumps", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "add package.json",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z",
+      files: {
+        "package.json": JSON.stringify(
+          {
+            dependencies: {
+              stripe: "^15.0.0",
+            },
+          },
+          null,
+          2
+        ),
+      },
+    });
+
+    commit(dir, {
+      message: "upgrade stripe dependency",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-02T10:00:00Z",
+      files: {
+        "package.json": JSON.stringify(
+          {
+            dependencies: {
+              stripe: "^16.0.0",
+            },
+          },
+          null,
+          2
+        ),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([
+      {
+        slug: "payments/stripe",
+        commit_count: 1,
+        first_seen: bundle.commits.first_at,
+        last_seen: bundle.commits.first_at,
+      },
+    ]);
+
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  });
+
+  it("detects dependencies when package.json is introduced", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "initial source file",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z",
+      files: {
+        "index.js": "console.log('hello');",
+      },
+    });
+
+    commit(dir, {
+      message: "add package.json with stripe",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-02T10:00:00Z",
+      files: {
+        "package.json": JSON.stringify(
+          {
+            dependencies: {
+              stripe: "^16.0.0",
+            },
+          },
+          null,
+          2
+        ),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([
+      {
+        slug: "payments/stripe",
+        commit_count: 1,
+        first_seen: bundle.commits.last_at,
+        last_seen: bundle.commits.last_at,
+      },
+    ]);
+
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  });  
+
 
   it("detects newly added Cargo.toml dependencies by comparing parent and child manifests", async () => {
     const dir = repo();
@@ -362,6 +528,7 @@ describe("runScan", () => {
       message: "add Cargo.toml",
       authorName: "Ivy",
       authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z",
       files: {
         "Cargo.toml": [
           "[package]",
@@ -377,6 +544,7 @@ describe("runScan", () => {
       message: "add tokio dependency",
       authorName: "Ivy",
       authorEmail: "ivy@example.com",
+      authorDate: "2026-01-02T10:00:00Z",
       files: {
         "Cargo.toml": [
           "[package]",
@@ -409,6 +577,161 @@ describe("runScan", () => {
     expect(validateAgainstSchema(schema, bundle)).toEqual([]);
   });
 
+  it("does not detect Cargo.toml dependency version bumps", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "add tokio dependency",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z",
+      files: {
+        "Cargo.toml": [
+          "[package]",
+          'name = "demo"',
+          'version = "0.1.0"',
+          "",
+          "[dependencies]",
+          'tokio = "1.0"',
+        ].join("\n"),
+      },
+    });
+
+    commit(dir, {
+      message: "upgrade tokio dependency",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-02T10:00:00Z",
+      files: {
+        "Cargo.toml": [
+          "[package]",
+          'name = "demo"',
+          'version = "0.1.0"',
+          "",
+          "[dependencies]",
+          'tokio = "1.1"',
+        ].join("\n"),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([
+      {
+        slug: "backend/tokio",
+        commit_count: 1,
+        first_seen: bundle.commits.first_at,
+        last_seen: bundle.commits.first_at,
+      },
+    ]);
+
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  });  
+
+  it("detects newly added Cargo.toml dependency blocks", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "add Cargo dependencies block",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z",
+      files: {
+        "Cargo.toml": [
+          "[package]",
+          'name = "demo"',
+          'version = "0.1.0"',
+          "",
+          "[dependencies]",
+        ].join("\n"),
+      },
+    });
+
+    commit(dir, {
+      message: "add tokio dependency",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-02T10:00:00Z",
+      files: {
+        "Cargo.toml": [
+          "[package]",
+          'name = "demo"',
+          'version = "0.1.0"',
+          "",
+          "[dependencies]",
+          'tokio = "1.0"',
+        ].join("\n"),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([
+      {
+        slug: "backend/tokio",
+        commit_count: 1,
+        first_seen: bundle.commits.last_at,
+        last_seen: bundle.commits.last_at,
+      },
+    ]);
+
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  });
+
+  it("detects dependencies when Cargo.toml is introduced", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "add Cargo.toml with tokio",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z", 
+      files: {
+        "Cargo.toml": [
+          "[package]",
+          'name = "demo"',
+          'version = "0.1.0"',
+          "",
+          "[dependencies]",
+          'tokio = "1.0"',
+        ].join("\n"),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([
+      {
+        slug: "backend/tokio",
+        commit_count: 1,
+        first_seen: bundle.commits.last_at,
+        last_seen: bundle.commits.last_at,
+      },
+    ]);
+
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  });  
 
   it("detects newly added composer.json dependencies by comparing parent and child manifests", async () => {
     const dir = repo();
@@ -418,6 +741,7 @@ describe("runScan", () => {
       message: "add composer.json",
       authorName: "Ivy",
       authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z",
       files: {
         "composer.json": JSON.stringify(
           {
@@ -433,6 +757,7 @@ describe("runScan", () => {
       message: "add laravel dependency",
       authorName: "Ivy",
       authorEmail: "ivy@example.com",
+      authorDate: "2026-01-02T10:00:00Z",
       files: {
         "composer.json": JSON.stringify(
           {
@@ -465,6 +790,166 @@ describe("runScan", () => {
 
     expect(validateAgainstSchema(schema, bundle)).toEqual([]);
   });
+
+  it("does not detect composer.json dependency version bumps", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "add laravel dependency",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z",
+      files: {
+        "composer.json": JSON.stringify(
+          {
+            require: {
+              "laravel/framework": "^10.0",
+            },
+          },
+          null,
+          2
+        ),
+      },
+    });
+
+    commit(dir, {
+      message: "upgrade laravel dependency",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-02T10:00:00Z",
+      files: {
+        "composer.json": JSON.stringify(
+          {
+            require: {
+              "laravel/framework": "^11.0",
+            },
+          },
+          null,
+          2
+        ),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([
+      {
+        slug: "backend/laravel",
+        commit_count: 1,
+        first_seen: bundle.commits.first_at,
+        last_seen: bundle.commits.first_at,
+      },
+    ]);
+
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  });  
+
+  it("detects newly added composer.json dependency blocks", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "add composer require block",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z", 
+      files: {
+        "composer.json": JSON.stringify(
+          {
+            require: {},
+          },
+          null,
+          2
+        ),
+      },
+    });
+
+    commit(dir, {
+      message: "add laravel dependency",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-02T10:00:00Z", 
+      files: {
+        "composer.json": JSON.stringify(
+          {
+            require: {
+              "laravel/framework": "^11.0",
+            },
+          },
+          null,
+          2
+        ),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([
+      {
+        slug: "backend/laravel",
+        commit_count: 1,
+        first_seen: bundle.commits.last_at,
+        last_seen: bundle.commits.last_at,
+      },
+    ]);
+
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  }); 
+
+  it("detects dependencies when composer.json is introduced", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "add composer.json with laravel",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z",
+      files: {
+        "composer.json": JSON.stringify(
+          {
+            require: {
+              "laravel/framework": "^11.0",
+            },
+          },
+          null,
+          2
+        ),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([
+      {
+        slug: "backend/laravel",
+        commit_count: 1,
+        first_seen: bundle.commits.last_at,
+        last_seen: bundle.commits.last_at,
+      },
+    ]);
+
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  });  
 
   it("does not detect a skill from a merge commit or from prose merely mentioning a library", async () => {
     const dir = repo();

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -378,11 +378,11 @@ describe("runScan", () => {
       authorEmail: "ivy@example.com",
       authorDate: "2026-01-02T10:00:00Z",
       files: {
-        "package.json": [
+       "package.json": [
           "{",
           '  "dependencies": {',
           '    "stripe": "^16.0.0",',
-          '    "react": "^19.0.0",',
+          '    "react": "^19.0.0"',
           "  }",
           "}",
         ].join("\n"),
@@ -398,13 +398,19 @@ describe("runScan", () => {
     });
 
     expect(bundle.detected_skills).toEqual([
-      {
-        slug: "payments/stripe",
-        commit_count: 1,
-        first_seen: bundle.commits.first_at,
-        last_seen: bundle.commits.first_at,
-      },
-    ]);
+    {
+      slug: "frontend/react",
+      commit_count: 1,
+      first_seen: bundle.commits.last_at,
+      last_seen: bundle.commits.last_at,
+    },
+    {
+      slug: "payments/stripe",
+      commit_count: 1,
+      first_seen: bundle.commits.first_at,
+      last_seen: bundle.commits.first_at,
+    },
+  ]);
 
     expect(validateAgainstSchema(schema, bundle)).toEqual([]);
   });  

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -300,7 +300,115 @@ describe("runScan", () => {
     ]);
     expect(validateAgainstSchema(schema, bundle)).toEqual([]);
   });
-  
+
+  it("does not detect dependencies when the parent package.json is malformed", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "add malformed package.json",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z",
+      files: {
+        "package.json": [
+          "{",
+          '  "dependencies": {',
+          '    "stripe": "^15.0.0"',
+        ].join("\n"),
+      },
+    });
+
+    commit(dir, {
+      message: "add dependency to package.json",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-02T10:00:00Z",
+      files: {
+        "package.json": JSON.stringify(
+          {
+            dependencies: {
+              stripe: "^16.0.0",
+            },
+          },
+          null,
+          2
+        ),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([]);
+
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  });
+
+  it("does not detect existing package.json dependencies when another dependency is added", async () => {
+    const dir = repo();
+    const configDir = tempConfigDir();
+
+    commit(dir, {
+      message: "add stripe dependency",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-01T10:00:00Z",
+      files: {
+        "package.json": JSON.stringify(
+          {
+            dependencies: {
+              stripe: "^16.0.0",
+            },
+          },
+          null,
+          2
+        ),
+      },
+    });
+
+    commit(dir, {
+      message: "add react dependency with formatting change",
+      authorName: "Ivy",
+      authorEmail: "ivy@example.com",
+      authorDate: "2026-01-02T10:00:00Z",
+      files: {
+        "package.json": [
+          "{",
+          '  "dependencies": {',
+          '    "stripe": "^16.0.0",',
+          '    "react": "^19.0.0",',
+          "  }",
+          "}",
+        ].join("\n"),
+      },
+    });
+
+    const bundle = await runScan({
+      repoPath: dir,
+      authors: ["ivy@example.com"],
+      confirmed: true,
+      toolVersion: "0.1.0",
+      configDir,
+    });
+
+    expect(bundle.detected_skills).toEqual([
+      {
+        slug: "payments/stripe",
+        commit_count: 1,
+        first_seen: bundle.commits.first_at,
+        last_seen: bundle.commits.first_at,
+      },
+    ]);
+
+    expect(validateAgainstSchema(schema, bundle)).toEqual([]);
+  });  
+    
   it("detects newly added package.json dependencies by comparing parent and child manifests", async () => {
     const dir = repo();
     const configDir = tempConfigDir();
@@ -650,7 +758,6 @@ describe("runScan", () => {
           'name = "demo"',
           'version = "0.1.0"',
           "",
-          "[dependencies]",
         ].join("\n"),
       },
     });
@@ -862,9 +969,7 @@ describe("runScan", () => {
       authorDate: "2026-01-01T10:00:00Z", 
       files: {
         "composer.json": JSON.stringify(
-          {
-            require: {},
-          },
+          {},
           null,
           2
         ),

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -345,8 +345,8 @@ describe("runScan", () => {
       {
         slug: "payments/stripe",
         commit_count: 1,
-        first_seen: bundle.commits.first_at,
-        last_seen: bundle.commits.first_at,
+        first_seen: bundle.commits.last_at,
+        last_seen: bundle.commits.last_at,
       },
     ]);
 
@@ -401,8 +401,8 @@ describe("runScan", () => {
       {
         slug: "backend/tokio",
         commit_count: 1,
-        first_seen: bundle.commits.first_at,
-        last_seen: bundle.commits.first_at,
+        first_seen: bundle.commits.last_at,
+        last_seen: bundle.commits.last_at,
       },
     ]);
 

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -281,7 +281,6 @@ describe("runScan", () => {
       },
     });
 
-
     const bundle = await runScan({
       repoPath: dir,
       authors: ["ivy@example.com"],
@@ -378,7 +377,7 @@ describe("runScan", () => {
       authorEmail: "ivy@example.com",
       authorDate: "2026-01-02T10:00:00Z",
       files: {
-       "package.json": [
+        "package.json": [
           "{",
           '  "dependencies": {',
           '    "stripe": "^16.0.0",',
@@ -398,23 +397,23 @@ describe("runScan", () => {
     });
 
     expect(bundle.detected_skills).toEqual([
-    {
-      slug: "frontend/react",
-      commit_count: 1,
-      first_seen: bundle.commits.last_at,
-      last_seen: bundle.commits.last_at,
-    },
-    {
-      slug: "payments/stripe",
-      commit_count: 1,
-      first_seen: bundle.commits.first_at,
-      last_seen: bundle.commits.first_at,
-    },
-  ]);
+      {
+        slug: "frontend/react",
+        commit_count: 1,
+        first_seen: bundle.commits.last_at,
+        last_seen: bundle.commits.last_at,
+      },
+      {
+        slug: "payments/stripe",
+        commit_count: 1,
+        first_seen: bundle.commits.first_at,
+        last_seen: bundle.commits.first_at,
+      },
+    ]);
 
     expect(validateAgainstSchema(schema, bundle)).toEqual([]);
-  });  
-    
+  });
+
   it("detects newly added package.json dependencies by comparing parent and child manifests", async () => {
     const dir = repo();
     const configDir = tempConfigDir();
@@ -631,7 +630,7 @@ describe("runScan", () => {
     ]);
 
     expect(validateAgainstSchema(schema, bundle)).toEqual([]);
-  });  
+  });
 
 
   it("detects newly added Cargo.toml dependencies by comparing parent and child manifests", async () => {
@@ -747,7 +746,7 @@ describe("runScan", () => {
     ]);
 
     expect(validateAgainstSchema(schema, bundle)).toEqual([]);
-  });  
+  });
 
   it("detects newly added Cargo.toml dependency blocks", async () => {
     const dir = repo();
@@ -813,7 +812,7 @@ describe("runScan", () => {
       message: "add Cargo.toml with tokio",
       authorName: "Ivy",
       authorEmail: "ivy@example.com",
-      authorDate: "2026-01-01T10:00:00Z", 
+      authorDate: "2026-01-01T10:00:00Z",
       files: {
         "Cargo.toml": [
           "[package]",
@@ -844,7 +843,7 @@ describe("runScan", () => {
     ]);
 
     expect(validateAgainstSchema(schema, bundle)).toEqual([]);
-  });  
+  });
 
   it("detects newly added composer.json dependencies by comparing parent and child manifests", async () => {
     const dir = repo();
@@ -962,7 +961,7 @@ describe("runScan", () => {
     ]);
 
     expect(validateAgainstSchema(schema, bundle)).toEqual([]);
-  });  
+  });
 
   it("detects newly added composer.json dependency blocks", async () => {
     const dir = repo();
@@ -972,7 +971,7 @@ describe("runScan", () => {
       message: "add composer require block",
       authorName: "Ivy",
       authorEmail: "ivy@example.com",
-      authorDate: "2026-01-01T10:00:00Z", 
+      authorDate: "2026-01-01T10:00:00Z",
       files: {
         "composer.json": JSON.stringify(
           {},
@@ -986,7 +985,7 @@ describe("runScan", () => {
       message: "add laravel dependency",
       authorName: "Ivy",
       authorEmail: "ivy@example.com",
-      authorDate: "2026-01-02T10:00:00Z", 
+      authorDate: "2026-01-02T10:00:00Z",
       files: {
         "composer.json": JSON.stringify(
           {
@@ -1018,7 +1017,7 @@ describe("runScan", () => {
     ]);
 
     expect(validateAgainstSchema(schema, bundle)).toEqual([]);
-  }); 
+  });
 
   it("detects dependencies when composer.json is introduced", async () => {
     const dir = repo();
@@ -1060,7 +1059,7 @@ describe("runScan", () => {
     ]);
 
     expect(validateAgainstSchema(schema, bundle)).toEqual([]);
-  });  
+  });
 
   it("does not detect a skill from a merge commit or from prose merely mentioning a library", async () => {
     const dir = repo();


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

This PR fixes a gap in manifest dependency detection where dependencies added
inside an existing dependency block were not detected.

Previously, manifest detection relied on added diff lines containing the
dependency section header (`dependencies`, `[dependencies]`, etc.). In common
cases where a dependency was added to an already existing block, the header was
not part of the diff context, causing the dependency to be missed.

This change makes manifest detection compare the complete manifest state before
and after a commit:

- Reads parent and child manifest snapshots locally using git blob contents.
- Detects dependencies that exist in the child manifest but not the parent.
- Avoids incorrectly attributing unchanged dependencies.
- Keeps version-only changes unattributed because they do not represent new
  dependency usage.
- Applies the same approach consistently across:
  - `package.json`
  - `composer.json`
  - `Cargo.toml`

This improves the reliability and verifiability of skill detection while
keeping the existing privacy model intact:
- All processing remains local.
- No additional data leaves the machine.
- The bundle shape and closed vocabulary remain unchanged.

Closes #58 

## Checklist

- [x] Tests pass locally (`npm test`)
- [x] `npm run typecheck` passes

### If this adds or changes a detection signature

- [x] Includes regression fixtures covering manifest dependency additions in:
  - `package.json`
  - `composer.json`
  - `Cargo.toml`
- [x] The slug used already exists in `taxonomy.json`

### If this touches WHAT data leaves the machine, or WHERE it's sent

- [x] No change to data leaving the machine.
- [x] No schema changes required.
- [x] No privacy test changes required.

### If this adds a new runtime dependency

- [x] No new runtime dependencies added.

### Docs and changelog

- [x] `CHANGELOG.md` entry added under `[Unreleased]`
- [x] Updated `docs/signatures.md` to document the new manifest detection
      behavior and remove the documented limitation.

## Additional context

The implementation changes manifest detection from a diff-line based approach
to a state comparison approach.

The previous behavior could not distinguish between:
- a dependency that was newly introduced, and
- an existing dependency line that appeared in the added diff because the
  surrounding manifest block changed.

By comparing parent and child manifest snapshots, detection now has enough
context to safely identify only newly introduced dependencies.

Privacy gate: run
- Boundary question: NO
- npm test / tsc: green
- Sweeps: clean