### PR TITLE
test: add signature near-miss fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning: strict [semver](https://semver.org/) — bundle schema changes
 always bump at least minor; breaking schema changes bump major.
 
-## [0.11.0] - 2026-08-10
+## [Unreleased]
 
-### Fixed
+### Added
 - Add near-miss negative fixtures for Firebase Auth, OAuth/OIDC, ActiveRecord, GitHub Actions, and Jest signature detection.
+
+## [0.11.0] - 2026-08-10
 
 ### Added
 - Add `payments/razorpay` to the closed skill taxonomy (#14).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ always bump at least minor; breaking schema changes bump major.
 
 ## [0.11.0] - 2026-08-10
 
+### Fixed
+- Add near-miss negative fixtures for Firebase Auth, OAuth/OIDC, ActiveRecord, GitHub Actions, and Jest signature detection.
+
 ### Added
 - Add `payments/razorpay` to the closed skill taxonomy (#14).
 - Detect Razorpay via `razorpay` and `react-native-razorpay` imports, mapped to `payments/razorpay` (#14).

--- a/signatures/auth/firebase-auth.json
+++ b/signatures/auth/firebase-auth.json
@@ -40,7 +40,7 @@
       },
       {
         "path": "src/docs/examples.ts",
-        "diff": "Firebase authentication uses signInWithRedirect(auth, provider) for browser login."
+        "diff": "// Firebase authentication uses signInWithRedirect(auth, provider) for browser login."
       }
     ]
   }

--- a/signatures/auth/firebase-auth.json
+++ b/signatures/auth/firebase-auth.json
@@ -37,6 +37,10 @@
       {
         "path": "src/lib/clerk.ts",
         "diff": "import { getAuth } from \"@clerk/nextjs/server\";\nconst { userId } = getAuth(req);"
+      },
+      {
+        "path": "src/docs/examples.ts",
+        "diff": "Firebase authentication uses signInWithRedirect(auth, provider) for browser login."
       }
     ]
   }

--- a/signatures/auth/oauth-oidc.json
+++ b/signatures/auth/oauth-oidc.json
@@ -35,6 +35,10 @@
       {
         "path": "README.md",
         "diff": "We discussed adding generic OAuth/OIDC support with PKCE and discovery documents but shipped Supabase's built-in provider instead."
+      },
+      {
+        "path": "src/auth/jose-oidc.ts",
+        "diff": "const packageName = \"openid-client\";\nconst discoveryUrl = `${issuer}/.well-known/openid-config`;\nconst response = await fetch(discoveryUrl);"
       }
     ]
   }

--- a/signatures/db/activerecord.json
+++ b/signatures/db/activerecord.json
@@ -15,6 +15,10 @@
       {
         "path": "README.md",
         "diff": "We use ActiveRecord for most models but this one talks to an external API instead of a table."
+      },
+      {
+        "path": "app/services/user_importer.rb",
+        "diff": "class UserImporter < ApplicationService\n  def call\n    # import users from the external API\n  end\nend"
       }
     ]
   }

--- a/signatures/infra/github-actions.json
+++ b/signatures/infra/github-actions.json
@@ -15,8 +15,8 @@
     "negative": [
       { "path": "README.md", "diff": "We use github actions for CI, but the workflow file hasn't been checked into the repo yet." },
       {
-        "path": "README.md",
-        "diff": "We use github actions for CI, but the workflow file hasn't been checked into the repo yet."
+      "path": "README.md",
+      "diff": "# Example workflow: uses: actions/checkout@v4\n"
       }
     ]
   }

--- a/signatures/infra/github-actions.json
+++ b/signatures/infra/github-actions.json
@@ -13,7 +13,11 @@
       { "path": ".github/workflows/ci.yml", "diff": "name: CI\non: [push]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - run: npm test" }
     ],
     "negative": [
-      { "path": "README.md", "diff": "We use github actions for CI, but the workflow file hasn't been checked into the repo yet." }
+      { "path": "README.md", "diff": "We use github actions for CI, but the workflow file hasn't been checked into the repo yet." },
+      {
+        "path": "README.md",
+        "diff": "We use github actions for CI, but the workflow file hasn't been checked into the repo yet."
+      }
     ]
   }
 }

--- a/signatures/testing/jest.json
+++ b/signatures/testing/jest.json
@@ -19,6 +19,10 @@
       {
         "path": "src/foo.test.ts",
         "diff": "import { describe, it, expect } from \"vitest\";\nit(\"matches the snapshot\", () => {\n  expect(result).toMatchSnapshot();\n});"
+      },
+      {
+        "path": "src/foo.test.ts",
+        "diff": "import { vi } from \"vitest\";\nconst mockFn = vi.fn();\nconst spy = vi.spyOn(console, \"log\");\nvi.mock(\"./foo\");\nconst framework = \"jest\";"
       }
     ]
   }


### PR DESCRIPTION
## What does this PR do, and why does it fit the north star?

This PR strengthens Tier 2 signature test coverage by adding genuine near-miss
negative fixtures for existing Firebase Auth, OAuth/OIDC, ActiveRecord,
GitHub Actions, and Jest signatures.

These fixtures represent code that looks similar to the corresponding
technology but should not match the signature. This helps verify that existing
signature detection remains precise and reduces the risk of false-positive
skill detection.

This fits the north star by making detected credentials more trustworthy and
verifiable through stronger fixture coverage.

Part of #27 

## Checklist

- [x] Tests pass locally (`npm test`)
- [ ] `npm run typecheck` passes

### If this adds or changes a detection signature

- [x] Includes at least one positive fixture and one negative fixture
      (the negative fixture is a genuine near-miss, not unrelated text)
- [x] The slug used already exists in `taxonomy.json` — if it's new, that's
      a **separate** PR with a rationale, linked here: #

### If this touches WHAT data leaves the machine, or WHERE it's sent

- [ ] Links the prior "Data boundary change" discussion issue (required
      before this PR was opened): #
- [ ] Schema version bumped, with `docs/schema.md` updated
- [ ] Adds/updates a test in `test/privacy/`

### If this adds a new runtime dependency

- [ ] Written justification included below (what it does, why the
      existing stack — commander/vitest — can't do it, what it adds to
      the supply-chain surface)

### Docs and changelog

- [x] `CHANGELOG.md` entry added under `[Unreleased]` (if user-facing)
- [ ] Relevant doc in `docs/` added or updated, in English

## Additional context

The changes are limited to existing Tier 2 signature fixtures and do not
modify the detection engine, add new taxonomy slugs, change runtime
dependencies, or change the data boundary.

The negative fixtures were chosen as genuine near-misses for each signature,
rather than unrelated text, so they exercise cases that could plausibly be
mistaken for a match.