### PR TITLE
fix(import-detect): strip trailing // comments on kept Go import lines

### DIFF
--- a/src/import-detect.ts
+++ b/src/import-detect.ts
@@ -280,6 +280,21 @@ function extractPython(text: string): string[] {
   return found;
 }
 
+// Strip a trailing `//` line comment from a kept Go import-block line before
+// the path regex runs. A line like `"fmt" // "github.com/spf13/cobra"` is not
+// a whole-line comment (so isCommentLine keeps it), yet the path regex would
+// otherwise match the quoted path sitting inside the comment. Only cut at a
+// `//` that is outside a string literal — a `//` could appear inside a quoted
+// path — reusing the same approximate quote tracking as isInsideStringLiteral.
+function stripGoLineComment(line: string): string {
+  for (let i = 0; i + 1 < line.length; i++) {
+    if (line[i] === "/" && line[i + 1] === "/" && !isInsideStringLiteral(line, i)) {
+      return line.slice(0, i);
+    }
+  }
+  return line;
+}
+
 function extractGo(text: string): string[] {
   const found: string[] = [];
   const normalize = (p: string) => p.replace(/\/v\d+$/, "");
@@ -297,9 +312,12 @@ function extractGo(text: string): string[] {
     // (`// "github.com/foo/bar"`) is not a real dependency. The single-line
     // form above already rejects these via isRealStatement; the block body
     // needs the same check per line, or a commented-out path is attributed.
+    // A kept line can also carry a trailing comment whose text holds a quoted
+    // path (`"fmt" // "github.com/spf13/cobra"`); strip that before matching.
     for (const line of m[1].split("\n")) {
       if (isCommentLine(line)) continue;
-      for (const p of line.matchAll(pathRe)) found.push(normalize(p[1]));
+      const code = stripGoLineComment(line);
+      for (const p of code.matchAll(pathRe)) found.push(normalize(p[1]));
     }
   }
   return found;

--- a/test/import-detect.test.ts
+++ b/test/import-detect.test.ts
@@ -130,6 +130,22 @@ describe("extractImportedPackages — Go", () => {
     const diff = 'import (\n\t"fmt"\n\t// "github.com/spf13/cobra"\n\t"github.com/gin-gonic/gin"\n)';
     expect(extractImportedPackages(diff, "main.go")).toEqual(["fmt", "github.com/gin-gonic/gin"]);
   });
+
+  it("keeps a kept path but ignores a quoted path in its trailing comment", () => {
+    const diff = 'import (\n\t"fmt" // "github.com/spf13/cobra"\n)';
+    expect(extractImportedPackages(diff, "main.go")).toEqual(["fmt"]);
+  });
+
+  it("drops a trailing-comment path while keeping the other real imports", () => {
+    const diff =
+      'import (\n\t"fmt"\n\t"github.com/gin-gonic/gin" // "github.com/spf13/cobra"\n)';
+    expect(extractImportedPackages(diff, "main.go")).toEqual(["fmt", "github.com/gin-gonic/gin"]);
+  });
+
+  it("does not treat // inside a quoted path as a comment", () => {
+    const diff = 'import (\n\t"github.com/foo//bar"\n)';
+    expect(extractImportedPackages(diff, "main.go")).toEqual(["github.com/foo//bar"]);
+  });
 });
 
 describe("extractImportedPackages — Ruby", () => {


### PR DESCRIPTION
Follow-up to #85, closes #88. A kept line inside a Go import block can carry a trailing comment that itself holds a quoted path:

```go
import (
    "fmt" // "github.com/spf13/cobra"
)
```

The block scanner skips whole-line `//` comments (that was #85) but ran the path regex over the whole kept line, so it still matched the path inside the comment and credited `github.com/spf13/cobra`. This strips the trailing `//` before matching, cutting only at a `//` outside a quoted string since Go paths use double quotes and a `//` can appear inside one. Reuses the existing `isInsideStringLiteral` tracking rather than adding a second approach.

Tests cover the kept-path-retained case, a mixed block, and the `//`-inside-a-quoted-path guard, same style as #85.