### PR TITLE
fix(import-detect): extract single-line Go dot imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning: strict [semver](https://semver.org/) — bundle schema changes
 always bump at least minor; breaking schema changes bump major.
 
+## [Unreleased]
+
+### Fixed
+- Tier 1 import extraction now credits a single-line Go dot import
+  (`import . "path"`). The block form and the blank/aliased single-line forms
+  already handled it, so dropping only this form was a false negative for
+  Ginkgo/Gomega-style test suites (#90, by @eeshsaxena).
+
 ## [0.15.1] - 2026-08-24
 
 ### Fixed

--- a/src/import-detect.ts
+++ b/src/import-detect.ts
@@ -298,8 +298,13 @@ function stripGoLineComment(line: string): string {
 function extractGo(text: string): string[] {
   const found: string[] = [];
   const normalize = (p: string) => p.replace(/\/v\d+$/, "");
-  // Single-line: import "path" or import alias "path"
-  const singleRe = /^[ \t]*import\s+(?:\w+\s+)?["']([^"'\n]+)["']/gm;
+  // Single-line: import "path", import alias "path", import _ "path"
+  // (blank), or import . "path" (dot import). Go's ImportSpec allows an
+  // optional local name that is either "." or a PackageName before the path;
+  // `_` is already covered by \w, but "." must be allowed explicitly or a
+  // single-line dot import (common in Ginkgo/Gomega test suites) is dropped
+  // even though the block form below already captures it.
+  const singleRe = /^[ \t]*import\s+(?:(?:\.|\w+)\s+)?["']([^"'\n]+)["']/gm;
   for (const m of text.matchAll(singleRe)) {
     if (isRealStatement(text, m.index!)) found.push(normalize(m[1]));
   }

--- a/test/import-detect.test.ts
+++ b/test/import-detect.test.ts
@@ -146,6 +146,21 @@ describe("extractImportedPackages — Go", () => {
     const diff = 'import (\n\t"github.com/foo//bar"\n)';
     expect(extractImportedPackages(diff, "main.go")).toEqual(["github.com/foo//bar"]);
   });
+
+  it("extracts a single-line blank import", () => {
+    expect(extractImportedPackages('import _ "github.com/lib/pq"', "main.go")).toEqual([
+      "github.com/lib/pq",
+    ]);
+  });
+
+  it("extracts a single-line dot import, matching the block form", () => {
+    // `import . "path"` merges the package's exported names into the file's
+    // scope; it is a real dependency (Ginkgo/Gomega test suites use it) and
+    // the block form already captures it, so the single-line form must too.
+    expect(extractImportedPackages('import . "github.com/onsi/ginkgo/v2"', "ginkgo_test.go")).toEqual([
+      "github.com/onsi/ginkgo",
+    ]);
+  });
 });
 
 describe("extractImportedPackages — Ruby", () => {


### PR DESCRIPTION
Found this while poking at single-line Go import forms after #85/#89.

The single-line Go import regex allows an optional local name before the path, but only as `\w+`:

```
/^[ \t]*import\s+(?:\w+\s+)?["']([^"'\n]+)["']/gm
```

That covers a named alias (`import gin "..."`) and the blank import (`import _ "..."`, since `_` is `\w`), but not the dot import (`import . "..."`), because `.` is not `\w`. Go's `ImportSpec` is `[ "." | PackageName ] ImportPath`, so `.` is valid there, and the block form already captures dot imports. So a single-line dot import was silently dropped:

| form | before | after |
|---|---|---|
| `import "path"` | ok | ok |
| `import gin "path"` | ok | ok |
| `import _ "path"` | ok | ok |
| `import . "path"` | **dropped** | ok |
| block `. "path"` | ok | ok |

Dot imports are real dependencies (Ginkgo/Gomega test suites lean on `. "github.com/onsi/ginkgo/v2"`), so this was a false negative that lost genuine Go evidence, and it was inconsistent with the block form.

The fix allows a leading `.` as the local name too. Added tests for the single-line blank and dot forms. Full suite (933 tests) and typecheck pass locally.
